### PR TITLE
feat: Railway volume CRUD tools (create, list, delete, resize)

### DIFF
--- a/railguey/__init__.py
+++ b/railguey/__init__.py
@@ -11,4 +11,5 @@ except PackageNotFoundError:
 def run():
     """Entry point for `railguey-mcp` console script (backward compat)."""
     from railguey.mcp import mcp
+
     mcp.run()

--- a/railguey/cli.py
+++ b/railguey/cli.py
@@ -170,7 +170,9 @@ def http_logs(workspace, service, deployment_id, limit):
 @click.option("--filter", "filter_str", default=None, help="Filter log lines.")
 def deployment_logs(workspace, deployment_id, limit, build, filter_str):
     """Get logs for a specific deployment by ID."""
-    _output(_run(tools.deployment_logs(workspace, deployment_id, limit, build, filter_str)))
+    _output(
+        _run(tools.deployment_logs(workspace, deployment_id, limit, build, filter_str))
+    )
 
 
 @main.command("unlink-repo")
@@ -197,4 +199,5 @@ def doctor(workspace):
 def serve():
     """Start the MCP server (for Claude Code, Cursor, etc.)."""
     from railguey.mcp import mcp
+
     mcp.run()

--- a/railguey/lib/__init__.py
+++ b/railguey/lib/__init__.py
@@ -1,8 +1,18 @@
 """railguey.lib — shared core with no framework dependencies."""
 
 from railguey.lib.token import _load_token
-from railguey.lib.cli_backend import _run_railway, _DEFAULT_TIMEOUT, _LOGS_TIMEOUT, _DEPLOY_TIMEOUT
-from railguey.lib.graphql import _gql, _resolve_project, _resolve_service_id, BACKBOARD_URL
+from railguey.lib.cli_backend import (
+    _run_railway,
+    _DEFAULT_TIMEOUT,
+    _LOGS_TIMEOUT,
+    _DEPLOY_TIMEOUT,
+)
+from railguey.lib.graphql import (
+    _gql,
+    _resolve_project,
+    _resolve_service_id,
+    BACKBOARD_URL,
+)
 from railguey.lib import tools
 
 __all__ = [

--- a/railguey/lib/accounts.py
+++ b/railguey/lib/accounts.py
@@ -72,7 +72,10 @@ def list_accounts() -> dict:
     config = _load_config()
     return {
         "accounts": {
-            name: {"email": acct.get("email", ""), "workspaces": acct.get("workspaces", {})}
+            name: {
+                "email": acct.get("email", ""),
+                "workspaces": acct.get("workspaces", {}),
+            }
             for name, acct in config["accounts"].items()
         },
         "default_account": config.get("default_account"),
@@ -149,7 +152,9 @@ def set_default_workspace(account_name: str, workspace_id: str) -> dict:
     return {"account": account_name, "default_workspace_id": workspace_id}
 
 
-def get_workspace_id(account_name: Optional[str] = None, workspace_name: Optional[str] = None) -> Optional[str]:
+def get_workspace_id(
+    account_name: Optional[str] = None, workspace_name: Optional[str] = None
+) -> Optional[str]:
     """Resolve workspace ID from account + workspace name."""
     config = _load_config()
     acct_name = account_name or config.get("default_account")

--- a/railguey/lib/cli_backend.py
+++ b/railguey/lib/cli_backend.py
@@ -24,7 +24,9 @@ async def _run_railway(
     """
     railway = shutil.which("railway")
     if not railway:
-        return {"error": "Railway CLI not found. Install it: https://docs.railway.com/guides/cli"}
+        return {
+            "error": "Railway CLI not found. Install it: https://docs.railway.com/guides/cli"
+        }
 
     token = _load_token(workspace)
     env = {**os.environ, "RAILWAY_TOKEN": token}
@@ -41,7 +43,9 @@ async def _run_railway(
         )
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except asyncio.TimeoutError:
-        return {"error": f"Command timed out after {timeout}s: railway {' '.join(args)}"}
+        return {
+            "error": f"Command timed out after {timeout}s: railway {' '.join(args)}"
+        }
     except Exception as exc:
         return {"error": str(exc)}
 
@@ -49,6 +53,10 @@ async def _run_railway(
     err = stderr.decode().strip() if stderr else ""
 
     if proc.returncode != 0:
-        return {"error": f"railway exited {proc.returncode}", "stderr": err, "output": out}
+        return {
+            "error": f"railway exited {proc.returncode}",
+            "stderr": err,
+            "output": out,
+        }
 
     return {"output": out}

--- a/railguey/lib/doctor.py
+++ b/railguey/lib/doctor.py
@@ -219,16 +219,19 @@ async def _check_repo_linking(token: str, project_data: dict) -> list:
         if "error" not in svc_result:
             triggers = svc_result.get("service", {}).get("repoTriggers", [])
             if triggers:
-                linked.append({
-                    "service": svc_name,
-                    "repo": triggers[0].get("repository", "unknown"),
-                })
+                linked.append(
+                    {
+                        "service": svc_name,
+                        "repo": triggers[0].get("repository", "unknown"),
+                    }
+                )
     return linked
 
 
 # =============================================================================
 # WORKSPACE-LEVEL CHECKS (no Railway API needed — just local filesystem)
 # =============================================================================
+
 
 def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, int]:
     """Run workspace-level checks. Returns (findings, score, max_score)."""
@@ -240,12 +243,22 @@ def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, in
     max_score += 1
     if has_token:
         score += 1
-        findings.append({"check": "RAILWAY_TOKEN", "status": "pass",
-                         "message": "Found in .env.local or .env"})
+        findings.append(
+            {
+                "check": "RAILWAY_TOKEN",
+                "status": "pass",
+                "message": "Found in .env.local or .env",
+            }
+        )
     else:
-        findings.append({"check": "RAILWAY_TOKEN", "status": "fail",
-                         "message": "Not found. Add RAILWAY_TOKEN=<your-project-token> to .env.local",
-                         "fix": "Get a project token from Railway dashboard > Project > Settings > Tokens"})
+        findings.append(
+            {
+                "check": "RAILWAY_TOKEN",
+                "status": "fail",
+                "message": "Not found. Add RAILWAY_TOKEN=<your-project-token> to .env.local",
+                "fix": "Get a project token from Railway dashboard > Project > Settings > Tokens",
+            }
+        )
 
     # 2. .env.local in .gitignore
     max_score += 1
@@ -259,78 +272,142 @@ def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, in
         )
     if env_ignored:
         score += 1
-        findings.append({"check": ".gitignore", "status": "pass",
-                         "message": ".env.local is gitignored"})
+        findings.append(
+            {
+                "check": ".gitignore",
+                "status": "pass",
+                "message": ".env.local is gitignored",
+            }
+        )
     else:
-        findings.append({"check": ".gitignore", "status": "warn",
-                         "message": ".env.local may not be gitignored — token could leak",
-                         "fix": "Add .env.local to your .gitignore file"})
+        findings.append(
+            {
+                "check": ".gitignore",
+                "status": "warn",
+                "message": ".env.local may not be gitignored — token could leak",
+                "fix": "Add .env.local to your .gitignore file",
+            }
+        )
 
     # 3. CI/CD workflow with --environment
     max_score += 1
     has_env_flag = bool(wf.get("environments") or wf.get("runtime_environments"))
     if wf["found"]:
         if not has_env_flag:
-            findings.append({
-                "check": "CI/CD workflow", "status": "warn",
-                "message": f"Deploy workflow found ({wf['file']}) but missing --environment flag.",
-                "fix": "Add --environment \"$RAILWAY_ENVIRONMENT\" to railway up command.",
-            })
-        elif len(wf["environments"]) > 1 and len(wf["branches"]) < len(wf["environments"]):
-            findings.append({
-                "check": "CI/CD workflow", "status": "warn",
-                "message": (f"Workflow targets {len(wf['environments'])} environment(s) "
-                            f"but only {len(wf['branches'])} branch(es) trigger it"),
-                "fix": "Add all deployment branches to on.push.branches",
-            })
+            findings.append(
+                {
+                    "check": "CI/CD workflow",
+                    "status": "warn",
+                    "message": f"Deploy workflow found ({wf['file']}) but missing --environment flag.",
+                    "fix": 'Add --environment "$RAILWAY_ENVIRONMENT" to railway up command.',
+                }
+            )
+        elif len(wf["environments"]) > 1 and len(wf["branches"]) < len(
+            wf["environments"]
+        ):
+            findings.append(
+                {
+                    "check": "CI/CD workflow",
+                    "status": "warn",
+                    "message": (
+                        f"Workflow targets {len(wf['environments'])} environment(s) "
+                        f"but only {len(wf['branches'])} branch(es) trigger it"
+                    ),
+                    "fix": "Add all deployment branches to on.push.branches",
+                }
+            )
         else:
             runtime = wf.get("runtime_environments", [])
             literal = wf["environments"]
-            env_desc = ", ".join(literal) if literal else ", ".join(runtime) + " (runtime variable)"
+            env_desc = (
+                ", ".join(literal)
+                if literal
+                else ", ".join(runtime) + " (runtime variable)"
+            )
             score += 1
-            findings.append({
-                "check": "CI/CD workflow", "status": "pass",
-                "message": (f"Deploy workflow covers {len(wf['branches'])} branch(es) "
-                            f"({', '.join(wf['branches'])}) → environment: {env_desc}"),
-            })
+            findings.append(
+                {
+                    "check": "CI/CD workflow",
+                    "status": "pass",
+                    "message": (
+                        f"Deploy workflow covers {len(wf['branches'])} branch(es) "
+                        f"({', '.join(wf['branches'])}) → environment: {env_desc}"
+                    ),
+                }
+            )
     else:
-        findings.append({
-            "check": "CI/CD workflow", "status": "warn",
-            "message": "No GitHub Actions deploy workflow found",
-            "fix": "Add .github/workflows/deploy.yml using the project token pattern.",
-        })
+        findings.append(
+            {
+                "check": "CI/CD workflow",
+                "status": "warn",
+                "message": "No GitHub Actions deploy workflow found",
+                "fix": "Add .github/workflows/deploy.yml using the project token pattern.",
+            }
+        )
 
     # 4. Token scope vs workflow environment targets
     # (workspace check — validates the workflow file, not the Railway API)
     max_score += 1
-    if has_token and wf["found"] and not wf["environments"] and wf.get("runtime_environments"):
+    if (
+        has_token
+        and wf["found"]
+        and not wf["environments"]
+        and wf.get("runtime_environments")
+    ):
         score += 1
-        findings.append({"check": "Token environment scope", "status": "pass",
-                         "message": "Environment set via runtime variable — ensure GitHub Actions variable matches token scope"})
+        findings.append(
+            {
+                "check": "Token environment scope",
+                "status": "pass",
+                "message": "Environment set via runtime variable — ensure GitHub Actions variable matches token scope",
+            }
+        )
     elif has_token and wf["found"] and not has_env_flag:
-        findings.append({"check": "Token environment scope", "status": "warn",
-                         "message": "Workflow missing --environment flag — cannot verify token scope",
-                         "fix": "Add --environment to your workflow"})
+        findings.append(
+            {
+                "check": "Token environment scope",
+                "status": "warn",
+                "message": "Workflow missing --environment flag — cannot verify token scope",
+                "fix": "Add --environment to your workflow",
+            }
+        )
     else:
-        findings.append({"check": "Token environment scope", "status": "skip",
-                         "message": "Cannot verify — need both token and workflow with --environment flags"})
+        findings.append(
+            {
+                "check": "Token environment scope",
+                "status": "skip",
+                "message": "Cannot verify — need both token and workflow with --environment flags",
+            }
+        )
 
     # 5. Dockerfile exists
     max_score += 1
     dockerfile = ws / "Dockerfile"
     if dockerfile.is_file():
         score += 1
-        findings.append({"check": "Dockerfile", "status": "pass", "message": "Dockerfile found"})
+        findings.append(
+            {"check": "Dockerfile", "status": "pass", "message": "Dockerfile found"}
+        )
     else:
         has_alt = (ws / "nixpacks.toml").is_file() or (ws / "railway.toml").is_file()
         if has_alt:
             score += 1
-            findings.append({"check": "Dockerfile", "status": "pass",
-                             "message": "No Dockerfile but nixpacks/railway config found"})
+            findings.append(
+                {
+                    "check": "Dockerfile",
+                    "status": "pass",
+                    "message": "No Dockerfile but nixpacks/railway config found",
+                }
+            )
         else:
-            findings.append({"check": "Dockerfile", "status": "warn",
-                             "message": "No Dockerfile — Railway will use Nixpacks auto-detection",
-                             "fix": "Consider adding a Dockerfile for reproducible builds"})
+            findings.append(
+                {
+                    "check": "Dockerfile",
+                    "status": "warn",
+                    "message": "No Dockerfile — Railway will use Nixpacks auto-detection",
+                    "fix": "Consider adding a Dockerfile for reproducible builds",
+                }
+            )
 
     # 6. .dockerignore
     max_score += 1
@@ -345,17 +422,32 @@ def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, in
         if not has_env:
             issues.append(".env* not excluded")
         if issues:
-            findings.append({"check": ".dockerignore", "status": "warn",
-                             "message": f".dockerignore exists but: {'; '.join(issues)}",
-                             "fix": "Add .git, .env*, node_modules to .dockerignore"})
+            findings.append(
+                {
+                    "check": ".dockerignore",
+                    "status": "warn",
+                    "message": f".dockerignore exists but: {'; '.join(issues)}",
+                    "fix": "Add .git, .env*, node_modules to .dockerignore",
+                }
+            )
         else:
             score += 1
-            findings.append({"check": ".dockerignore", "status": "pass",
-                             "message": ".dockerignore present with .git and .env* excluded"})
+            findings.append(
+                {
+                    "check": ".dockerignore",
+                    "status": "pass",
+                    "message": ".dockerignore present with .git and .env* excluded",
+                }
+            )
     else:
-        findings.append({"check": ".dockerignore", "status": "warn",
-                         "message": "No .dockerignore — entire directory sent as build context",
-                         "fix": "Create .dockerignore excluding .git, .env*, node_modules, docs"})
+        findings.append(
+            {
+                "check": ".dockerignore",
+                "status": "warn",
+                "message": "No .dockerignore — entire directory sent as build context",
+                "fix": "Create .dockerignore excluding .git, .env*, node_modules, docs",
+            }
+        )
 
     # 7. Git repository with remote
     max_score += 1
@@ -367,76 +459,142 @@ def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, in
         if git_config.is_file():
             has_remote = '[remote "origin"]' in git_config.read_text()
     if not has_git:
-        findings.append({"check": "Git repository", "status": "fail",
-                         "message": "Not a git repository",
-                         "fix": "Run: git init && git remote add origin <repo-url>"})
+        findings.append(
+            {
+                "check": "Git repository",
+                "status": "fail",
+                "message": "Not a git repository",
+                "fix": "Run: git init && git remote add origin <repo-url>",
+            }
+        )
     elif not has_remote:
-        findings.append({"check": "Git repository", "status": "fail",
-                         "message": "No git remote configured",
-                         "fix": "git remote add origin <repo-url>"})
+        findings.append(
+            {
+                "check": "Git repository",
+                "status": "fail",
+                "message": "No git remote configured",
+                "fix": "git remote add origin <repo-url>",
+            }
+        )
     else:
         score += 1
-        findings.append({"check": "Git repository", "status": "pass",
-                         "message": "Git remote configured"})
+        findings.append(
+            {
+                "check": "Git repository",
+                "status": "pass",
+                "message": "Git remote configured",
+            }
+        )
 
     # 8. Uncommitted changes
     max_score += 1
     if has_git:
         import subprocess
+
         try:
             result_git = subprocess.run(
                 ["git", "status", "--porcelain"],
-                cwd=str(ws), capture_output=True, text=True, timeout=10,
+                cwd=str(ws),
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
-            dirty_files = [ln for ln in result_git.stdout.strip().splitlines() if ln.strip()]
+            dirty_files = [
+                ln for ln in result_git.stdout.strip().splitlines() if ln.strip()
+            ]
             if dirty_files:
-                findings.append({"check": "Uncommitted changes", "status": "warn",
-                                 "message": f"{len(dirty_files)} uncommitted file(s)",
-                                 "fix": "Commit and push before deploying"})
+                findings.append(
+                    {
+                        "check": "Uncommitted changes",
+                        "status": "warn",
+                        "message": f"{len(dirty_files)} uncommitted file(s)",
+                        "fix": "Commit and push before deploying",
+                    }
+                )
             else:
                 score += 1
-                findings.append({"check": "Uncommitted changes", "status": "pass",
-                                 "message": "Working tree is clean"})
+                findings.append(
+                    {
+                        "check": "Uncommitted changes",
+                        "status": "pass",
+                        "message": "Working tree is clean",
+                    }
+                )
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            findings.append({"check": "Uncommitted changes", "status": "skip",
-                             "message": "Could not run git status"})
+            findings.append(
+                {
+                    "check": "Uncommitted changes",
+                    "status": "skip",
+                    "message": "Could not run git status",
+                }
+            )
     else:
-        findings.append({"check": "Uncommitted changes", "status": "skip",
-                         "message": "Not a git repository"})
+        findings.append(
+            {
+                "check": "Uncommitted changes",
+                "status": "skip",
+                "message": "Not a git repository",
+            }
+        )
 
     # 9. Package manifest + lockfile
     max_score += 1
     manifest_names = ("package.json", "pyproject.toml", "requirements.txt")
     lockfile_names = (
-        "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
-        "bun.lockb", "poetry.lock", "uv.lock",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+        "poetry.lock",
+        "uv.lock",
     )
-    search_dirs = [ws] + [d for d in ws.iterdir() if d.is_dir() and not d.name.startswith(".")]
+    search_dirs = [ws] + [
+        d for d in ws.iterdir() if d.is_dir() and not d.name.startswith(".")
+    ]
     has_manifest = any((d / m).is_file() for d in search_dirs for m in manifest_names)
     has_lockfile = any((d / lf).is_file() for d in search_dirs for lf in lockfile_names)
     if has_manifest:
         if has_lockfile:
             score += 1
-            findings.append({"check": "Local setup", "status": "pass",
-                             "message": "Package manifest and lockfile present"})
+            findings.append(
+                {
+                    "check": "Local setup",
+                    "status": "pass",
+                    "message": "Package manifest and lockfile present",
+                }
+            )
         else:
-            findings.append({"check": "Local setup", "status": "warn",
-                             "message": "Package manifest found but no lockfile — builds may be non-deterministic",
-                             "fix": "Run your package manager's install command to generate a lockfile"})
+            findings.append(
+                {
+                    "check": "Local setup",
+                    "status": "warn",
+                    "message": "Package manifest found but no lockfile — builds may be non-deterministic",
+                    "fix": "Run your package manager's install command to generate a lockfile",
+                }
+            )
     else:
-        findings.append({"check": "Local setup", "status": "warn",
-                         "message": "No package manifest found",
-                         "fix": "Add package.json, pyproject.toml, or requirements.txt"})
+        findings.append(
+            {
+                "check": "Local setup",
+                "status": "warn",
+                "message": "No package manifest found",
+                "fix": "Add package.json, pyproject.toml, or requirements.txt",
+            }
+        )
 
     # 10. CI/CD health (latest GitHub Actions run)
     max_score += 1
     has_git_remote = has_git and has_remote
     if has_git_remote:
         import subprocess
+
         try:
             remote_result = subprocess.run(
                 ["git", "remote", "get-url", "origin"],
-                cwd=str(ws), capture_output=True, text=True, timeout=10,
+                cwd=str(ws),
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             remote_url = remote_result.stdout.strip()
             repo_slug = None
@@ -448,10 +606,23 @@ def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, in
 
             if repo_slug:
                 import json as _json
+
                 gh_result = subprocess.run(
-                    ["gh", "run", "list", "--repo", repo_slug, "--limit", "1",
-                     "--json", "status,conclusion,name,headBranch"],
-                    cwd=str(ws), capture_output=True, text=True, timeout=15,
+                    [
+                        "gh",
+                        "run",
+                        "list",
+                        "--repo",
+                        repo_slug,
+                        "--limit",
+                        "1",
+                        "--json",
+                        "status,conclusion,name,headBranch",
+                    ],
+                    cwd=str(ws),
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
                 )
                 if gh_result.returncode == 0 and gh_result.stdout.strip():
                     runs = _json.loads(gh_result.stdout)
@@ -463,32 +634,68 @@ def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, in
                         branch = run.get("headBranch", "unknown")
                         if conclusion == "success":
                             score += 1
-                            findings.append({"check": "CI/CD health", "status": "pass",
-                                             "message": f"Latest run '{name}' on {branch}: success"})
+                            findings.append(
+                                {
+                                    "check": "CI/CD health",
+                                    "status": "pass",
+                                    "message": f"Latest run '{name}' on {branch}: success",
+                                }
+                            )
                         elif status_str in ("in_progress", "queued", "waiting"):
-                            findings.append({"check": "CI/CD health", "status": "warn",
-                                             "message": f"Run '{name}' on {branch}: {status_str}",
-                                             "fix": "Wait for CI/CD run to complete"})
+                            findings.append(
+                                {
+                                    "check": "CI/CD health",
+                                    "status": "warn",
+                                    "message": f"Run '{name}' on {branch}: {status_str}",
+                                    "fix": "Wait for CI/CD run to complete",
+                                }
+                            )
                         else:
-                            findings.append({"check": "CI/CD health", "status": "fail",
-                                             "message": f"Latest run '{name}' on {branch}: {conclusion or status_str}",
-                                             "fix": "Check: gh run view --log"})
+                            findings.append(
+                                {
+                                    "check": "CI/CD health",
+                                    "status": "fail",
+                                    "message": f"Latest run '{name}' on {branch}: {conclusion or status_str}",
+                                    "fix": "Check: gh run view --log",
+                                }
+                            )
                     else:
-                        findings.append({"check": "CI/CD health", "status": "warn",
-                                         "message": "No GitHub Actions runs found",
-                                         "fix": "Push a commit to trigger the deploy workflow"})
+                        findings.append(
+                            {
+                                "check": "CI/CD health",
+                                "status": "warn",
+                                "message": "No GitHub Actions runs found",
+                                "fix": "Push a commit to trigger the deploy workflow",
+                            }
+                        )
                 else:
-                    findings.append({"check": "CI/CD health", "status": "skip",
-                                     "message": "Could not query GitHub Actions"})
+                    findings.append(
+                        {
+                            "check": "CI/CD health",
+                            "status": "skip",
+                            "message": "Could not query GitHub Actions",
+                        }
+                    )
             else:
-                findings.append({"check": "CI/CD health", "status": "skip",
-                                 "message": "Remote is not GitHub"})
+                findings.append(
+                    {
+                        "check": "CI/CD health",
+                        "status": "skip",
+                        "message": "Remote is not GitHub",
+                    }
+                )
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            findings.append({"check": "CI/CD health", "status": "skip",
-                             "message": "Could not run gh CLI"})
+            findings.append(
+                {
+                    "check": "CI/CD health",
+                    "status": "skip",
+                    "message": "Could not run gh CLI",
+                }
+            )
     else:
-        findings.append({"check": "CI/CD health", "status": "skip",
-                         "message": "No git remote"})
+        findings.append(
+            {"check": "CI/CD health", "status": "skip", "message": "No git remote"}
+        )
 
     return findings, score, max_score
 
@@ -496,6 +703,7 @@ def _check_workspace(ws: Path, wf: dict, has_token: bool) -> tuple[list, int, in
 # =============================================================================
 # SERVICE-LEVEL CHECKS (this service only — needs Railway API)
 # =============================================================================
+
 
 async def doctor_service_level(workspace: str, service: str | None = None) -> dict:
     """Check a single service's Railway deployment health.
@@ -520,15 +728,31 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
     try:
         token = _load_token(workspace)
     except ValueError:
-        return {"score": "0/0", "findings": [
-            {"check": "Token", "status": "fail", "message": "No RAILWAY_TOKEN — cannot check service"}
-        ], "healthy": False}
+        return {
+            "score": "0/0",
+            "findings": [
+                {
+                    "check": "Token",
+                    "status": "fail",
+                    "message": "No RAILWAY_TOKEN — cannot check service",
+                }
+            ],
+            "healthy": False,
+        }
 
     project_data = await _fetch_project_data(token, workspace)
     if "error" in project_data:
-        return {"score": "0/0", "findings": [
-            {"check": "Railway API", "status": "fail", "message": project_data["error"]}
-        ], "healthy": False}
+        return {
+            "score": "0/0",
+            "findings": [
+                {
+                    "check": "Railway API",
+                    "status": "fail",
+                    "message": project_data["error"],
+                }
+            ],
+            "healthy": False,
+        }
 
     # Detect service name
     wf = _parse_workflow_details(ws / ".github" / "workflows")
@@ -536,11 +760,19 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
     svc_data = project_data["services"].get(svc_name)
 
     if not svc_data:
-        return {"score": "0/0", "findings": [
-            {"check": "Service", "status": "fail",
-             "message": f"Service '{svc_name}' not found in Railway project '{project_data['project_name']}'",
-             "fix": f"Available services: {', '.join(project_data['services'].keys())}"}
-        ], "healthy": False, "service": svc_name}
+        return {
+            "score": "0/0",
+            "findings": [
+                {
+                    "check": "Service",
+                    "status": "fail",
+                    "message": f"Service '{svc_name}' not found in Railway project '{project_data['project_name']}'",
+                    "fix": f"Available services: {', '.join(project_data['services'].keys())}",
+                }
+            ],
+            "healthy": False,
+            "service": svc_name,
+        }
 
     # 1. This service's deployment health
     max_score += 1
@@ -551,31 +783,61 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
         in_progress = {"BUILDING", "DEPLOYING", "INITIALIZING", "WAITING"}
         if status in healthy_statuses:
             score += 1
-            findings.append({"check": "Deployment health", "status": "pass",
-                             "message": f"{svc_name}: latest deployment {status}"})
+            findings.append(
+                {
+                    "check": "Deployment health",
+                    "status": "pass",
+                    "message": f"{svc_name}: latest deployment {status}",
+                }
+            )
         elif status in in_progress:
-            findings.append({"check": "Deployment health", "status": "warn",
-                             "message": f"{svc_name}: deployment {status} — not done yet",
-                             "fix": "Wait for deploy to complete, then re-run"})
+            findings.append(
+                {
+                    "check": "Deployment health",
+                    "status": "warn",
+                    "message": f"{svc_name}: deployment {status} — not done yet",
+                    "fix": "Wait for deploy to complete, then re-run",
+                }
+            )
         else:
-            findings.append({"check": "Deployment health", "status": "fail",
-                             "message": f"{svc_name}: latest deployment {status}",
-                             "fix": "Check railguey_deployment_logs for error details"})
+            findings.append(
+                {
+                    "check": "Deployment health",
+                    "status": "fail",
+                    "message": f"{svc_name}: latest deployment {status}",
+                    "fix": "Check railguey_deployment_logs for error details",
+                }
+            )
     else:
-        findings.append({"check": "Deployment health", "status": "warn",
-                         "message": f"{svc_name}: no deployments found",
-                         "fix": "Deploy with railguey_deploy or push to trigger CI/CD"})
+        findings.append(
+            {
+                "check": "Deployment health",
+                "status": "warn",
+                "message": f"{svc_name}: no deployments found",
+                "fix": "Deploy with railguey_deploy or push to trigger CI/CD",
+            }
+        )
 
     # 2. This service's domain configuration
     max_score += 1
     if svc_data["domains"]:
         score += 1
-        findings.append({"check": "Domain", "status": "pass",
-                         "message": f"{svc_name}: {', '.join(svc_data['domains'])}"})
+        findings.append(
+            {
+                "check": "Domain",
+                "status": "pass",
+                "message": f"{svc_name}: {', '.join(svc_data['domains'])}",
+            }
+        )
     else:
-        findings.append({"check": "Domain", "status": "warn",
-                         "message": f"{svc_name}: no public domain configured",
-                         "fix": "Use railguey_domain to generate one (or skip if this is a background worker)"})
+        findings.append(
+            {
+                "check": "Domain",
+                "status": "warn",
+                "message": f"{svc_name}: no public domain configured",
+                "fix": "Use railguey_domain to generate one (or skip if this is a background worker)",
+            }
+        )
 
     # 3. Deploy drift (local code vs this service's deploy)
     max_score += 1
@@ -583,10 +845,14 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
     if git_dir.is_dir() and dep and dep.get("createdAt"):
         import subprocess
         from datetime import datetime, timezone
+
         try:
             head_result = subprocess.run(
                 ["git", "log", "-1", "--format=%cI"],
-                cwd=str(ws), capture_output=True, text=True, timeout=10,
+                cwd=str(ws),
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             local_commit_str = head_result.stdout.strip()
             if local_commit_str:
@@ -600,22 +866,47 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
                 if local_time > deploy_time:
                     delta = local_time - deploy_time
                     mins = int(delta.total_seconds() // 60)
-                    findings.append({"check": "Deploy drift", "status": "warn",
-                                     "message": f"{svc_name}: local code is {mins}m ahead of deployed code",
-                                     "fix": "Push to trigger CI/CD or run railguey_deploy"})
+                    findings.append(
+                        {
+                            "check": "Deploy drift",
+                            "status": "warn",
+                            "message": f"{svc_name}: local code is {mins}m ahead of deployed code",
+                            "fix": "Push to trigger CI/CD or run railguey_deploy",
+                        }
+                    )
                 else:
                     score += 1
-                    findings.append({"check": "Deploy drift", "status": "pass",
-                                     "message": f"{svc_name}: deployed code is up to date"})
+                    findings.append(
+                        {
+                            "check": "Deploy drift",
+                            "status": "pass",
+                            "message": f"{svc_name}: deployed code is up to date",
+                        }
+                    )
             else:
-                findings.append({"check": "Deploy drift", "status": "skip",
-                                 "message": "Could not get local commit time"})
+                findings.append(
+                    {
+                        "check": "Deploy drift",
+                        "status": "skip",
+                        "message": "Could not get local commit time",
+                    }
+                )
         except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
-            findings.append({"check": "Deploy drift", "status": "skip",
-                             "message": "Could not determine deploy drift"})
+            findings.append(
+                {
+                    "check": "Deploy drift",
+                    "status": "skip",
+                    "message": "Could not determine deploy drift",
+                }
+            )
     else:
-        findings.append({"check": "Deploy drift", "status": "skip",
-                         "message": "Need git repo and deployment to check drift"})
+        findings.append(
+            {
+                "check": "Deploy drift",
+                "status": "skip",
+                "message": "Need git repo and deployment to check drift",
+            }
+        )
 
     # 4. Token scope vs workflow environments (API-validated)
     max_score += 1
@@ -629,6 +920,7 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
             # Check if the account system covers the gap
             try:
                 from railguey.lib.accounts import list_accounts
+
                 accts = list_accounts()
                 acct_names = set(accts.get("accounts", {}).keys())
                 has_accounts = len(acct_names) >= 2
@@ -637,31 +929,58 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
 
             if has_accounts:
                 score += 1
-                findings.append({
-                    "check": "Token environment scope", "status": "pass",
-                    "message": (f"Token scoped to '{token_env_name}' but "
-                                f"account system covers {', '.join(sorted(uncovered))} — "
-                                f"use railguey_account_default to switch"),
-                })
+                findings.append(
+                    {
+                        "check": "Token environment scope",
+                        "status": "pass",
+                        "message": (
+                            f"Token scoped to '{token_env_name}' but "
+                            f"account system covers {', '.join(sorted(uncovered))} — "
+                            f"use railguey_account_default to switch"
+                        ),
+                    }
+                )
             else:
-                findings.append({
-                    "check": "Token environment scope", "status": "fail",
-                    "message": (f"Token scoped to '{token_env_name}' but workflow targets: "
-                                f"{', '.join(sorted(uncovered))}"),
-                    "fix": ("Register tokens for each environment with railguey_account_add, "
-                            "then switch with railguey_account_default"),
-                })
+                findings.append(
+                    {
+                        "check": "Token environment scope",
+                        "status": "fail",
+                        "message": (
+                            f"Token scoped to '{token_env_name}' but workflow targets: "
+                            f"{', '.join(sorted(uncovered))}"
+                        ),
+                        "fix": (
+                            "Register tokens for each environment with railguey_account_add, "
+                            "then switch with railguey_account_default"
+                        ),
+                    }
+                )
         else:
             score += 1
-            findings.append({"check": "Token environment scope", "status": "pass",
-                             "message": f"Token scoped to '{token_env_name}' — matches workflow"})
+            findings.append(
+                {
+                    "check": "Token environment scope",
+                    "status": "pass",
+                    "message": f"Token scoped to '{token_env_name}' — matches workflow",
+                }
+            )
     elif wf["found"] and wf.get("runtime_environments"):
         score += 1
-        findings.append({"check": "Token environment scope", "status": "pass",
-                         "message": "Environment set via runtime variable"})
+        findings.append(
+            {
+                "check": "Token environment scope",
+                "status": "pass",
+                "message": "Environment set via runtime variable",
+            }
+        )
     else:
-        findings.append({"check": "Token environment scope", "status": "skip",
-                         "message": "Cannot verify — need workflow with --environment flags"})
+        findings.append(
+            {
+                "check": "Token environment scope",
+                "status": "skip",
+                "message": "Cannot verify — need workflow with --environment flags",
+            }
+        )
 
     # 5. Workflow environment names match Railway
     max_score += 1
@@ -670,23 +989,39 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
         workflow_envs = set(wf["environments"])
         invalid = workflow_envs - railway_env_names
         if invalid:
-            findings.append({
-                "check": "Environment names", "status": "fail",
-                "message": (f"Workflow references unknown environment(s): {', '.join(sorted(invalid))}. "
-                            f"Railway has: {', '.join(sorted(railway_env_names))}"),
-                "fix": "Fix --environment values to match Railway environment names",
-            })
+            findings.append(
+                {
+                    "check": "Environment names",
+                    "status": "fail",
+                    "message": (
+                        f"Workflow references unknown environment(s): {', '.join(sorted(invalid))}. "
+                        f"Railway has: {', '.join(sorted(railway_env_names))}"
+                    ),
+                    "fix": "Fix --environment values to match Railway environment names",
+                }
+            )
         else:
             score += 1
-            findings.append({"check": "Environment names", "status": "pass",
-                             "message": f"Workflow environments match Railway: {', '.join(sorted(workflow_envs))}"})
+            findings.append(
+                {
+                    "check": "Environment names",
+                    "status": "pass",
+                    "message": f"Workflow environments match Railway: {', '.join(sorted(workflow_envs))}",
+                }
+            )
     elif wf["found"] and wf.get("runtime_environments"):
         score += 1
-        findings.append({"check": "Environment names", "status": "pass",
-                         "message": "Environment set via runtime variable"})
+        findings.append(
+            {
+                "check": "Environment names",
+                "status": "pass",
+                "message": "Environment set via runtime variable",
+            }
+        )
     else:
-        findings.append({"check": "Environment names", "status": "skip",
-                         "message": "Cannot verify"})
+        findings.append(
+            {"check": "Environment names", "status": "skip", "message": "Cannot verify"}
+        )
 
     skipped = sum(1 for f in findings if f["status"] == "skip")
     effective_max = max_score - skipped
@@ -702,6 +1037,7 @@ async def doctor_service_level(workspace: str, service: str | None = None) -> di
 # =============================================================================
 # PROJECT-LEVEL CHECKS (all services — cross-service visibility)
 # =============================================================================
+
 
 async def doctor_project_level(workspace: str) -> dict:
     """Check the entire Railway project's health.
@@ -722,15 +1058,31 @@ async def doctor_project_level(workspace: str) -> dict:
     try:
         token = _load_token(workspace)
     except ValueError:
-        return {"score": "0/0", "findings": [
-            {"check": "Token", "status": "fail", "message": "No RAILWAY_TOKEN — cannot check project"}
-        ], "healthy": False}
+        return {
+            "score": "0/0",
+            "findings": [
+                {
+                    "check": "Token",
+                    "status": "fail",
+                    "message": "No RAILWAY_TOKEN — cannot check project",
+                }
+            ],
+            "healthy": False,
+        }
 
     project_data = await _fetch_project_data(token, workspace)
     if "error" in project_data:
-        return {"score": "0/0", "findings": [
-            {"check": "Railway API", "status": "fail", "message": project_data["error"]}
-        ], "healthy": False}
+        return {
+            "score": "0/0",
+            "findings": [
+                {
+                    "check": "Railway API",
+                    "status": "fail",
+                    "message": project_data["error"],
+                }
+            ],
+            "healthy": False,
+        }
 
     services = project_data["services"]
     project_name = project_data["project_name"]
@@ -739,16 +1091,24 @@ async def doctor_project_level(workspace: str) -> dict:
     max_score += 1
     linked = await _check_repo_linking(token, project_data)
     if linked:
-        findings.append({
-            "check": "GitHub repo linking", "status": "warn",
-            "message": f"{len(linked)} service(s) linked to GitHub repos (brittle auto-deploy)",
-            "linked": linked,
-            "fix": "Use railguey_unlink_repo, then set up GitHub Actions CI/CD",
-        })
+        findings.append(
+            {
+                "check": "GitHub repo linking",
+                "status": "warn",
+                "message": f"{len(linked)} service(s) linked to GitHub repos (brittle auto-deploy)",
+                "linked": linked,
+                "fix": "Use railguey_unlink_repo, then set up GitHub Actions CI/CD",
+            }
+        )
     else:
         score += 1
-        findings.append({"check": "GitHub repo linking", "status": "pass",
-                         "message": "No services linked to GitHub repos (good — using token-based deploys)"})
+        findings.append(
+            {
+                "check": "GitHub repo linking",
+                "status": "pass",
+                "message": "No services linked to GitHub repos (good — using token-based deploys)",
+            }
+        )
 
     # 2. Deployment health across all services
     max_score += 1
@@ -764,29 +1124,54 @@ async def doctor_project_level(workspace: str) -> dict:
             elif status not in healthy_statuses:
                 failed.append(f"{svc_name} ({status})")
     if failed:
-        findings.append({"check": "Deployment health", "status": "fail",
-                         "message": f"Failed: {', '.join(failed)}",
-                         "fix": "Check railguey_deployment_logs for each failed service"})
+        findings.append(
+            {
+                "check": "Deployment health",
+                "status": "fail",
+                "message": f"Failed: {', '.join(failed)}",
+                "fix": "Check railguey_deployment_logs for each failed service",
+            }
+        )
     elif in_progress:
-        findings.append({"check": "Deployment health", "status": "warn",
-                         "message": f"In progress: {', '.join(in_progress)}",
-                         "fix": "Wait for deploys to complete"})
+        findings.append(
+            {
+                "check": "Deployment health",
+                "status": "warn",
+                "message": f"In progress: {', '.join(in_progress)}",
+                "fix": "Wait for deploys to complete",
+            }
+        )
     else:
         score += 1
-        findings.append({"check": "Deployment health", "status": "pass",
-                         "message": "All services healthy"})
+        findings.append(
+            {
+                "check": "Deployment health",
+                "status": "pass",
+                "message": "All services healthy",
+            }
+        )
 
     # 3. Domain coverage
     max_score += 1
     no_domain = [name for name, data in services.items() if not data["domains"]]
     if no_domain:
-        findings.append({"check": "Domain coverage", "status": "warn",
-                         "message": f"No domain: {', '.join(no_domain)}",
-                         "fix": "Use railguey_domain (or skip for background workers)"})
+        findings.append(
+            {
+                "check": "Domain coverage",
+                "status": "warn",
+                "message": f"No domain: {', '.join(no_domain)}",
+                "fix": "Use railguey_domain (or skip for background workers)",
+            }
+        )
     else:
         score += 1
-        findings.append({"check": "Domain coverage", "status": "pass",
-                         "message": "All services have at least one domain"})
+        findings.append(
+            {
+                "check": "Domain coverage",
+                "status": "pass",
+                "message": "All services have at least one domain",
+            }
+        )
 
     # 4. Deploy drift across all services
     max_score += 1
@@ -795,10 +1180,14 @@ async def doctor_project_level(workspace: str) -> dict:
     if git_dir.is_dir():
         import subprocess
         from datetime import datetime, timezone
+
         try:
             head_result = subprocess.run(
                 ["git", "log", "-1", "--format=%cI"],
-                cwd=str(ws), capture_output=True, text=True, timeout=10,
+                cwd=str(ws),
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             local_commit_str = head_result.stdout.strip()
             if local_commit_str:
@@ -815,28 +1204,54 @@ async def doctor_project_level(workspace: str) -> dict:
                             stale.append(f"{svc_name} ({status.lower()})")
                             continue
                         deploy_time = datetime.fromisoformat(
-                            dep["createdAt"].replace("Z", "+00:00"))
+                            dep["createdAt"].replace("Z", "+00:00")
+                        )
                         if local_time > deploy_time:
                             mins = int((local_time - deploy_time).total_seconds() // 60)
                             stale.append(f"{svc_name} ({mins}m behind)")
 
                 if stale:
-                    findings.append({"check": "Deploy drift", "status": "warn",
-                                     "message": f"Behind: {', '.join(stale)}",
-                                     "fix": "Deploy or push to trigger CI/CD"})
+                    findings.append(
+                        {
+                            "check": "Deploy drift",
+                            "status": "warn",
+                            "message": f"Behind: {', '.join(stale)}",
+                            "fix": "Deploy or push to trigger CI/CD",
+                        }
+                    )
                 else:
                     score += 1
-                    findings.append({"check": "Deploy drift", "status": "pass",
-                                     "message": "All services up to date"})
+                    findings.append(
+                        {
+                            "check": "Deploy drift",
+                            "status": "pass",
+                            "message": "All services up to date",
+                        }
+                    )
             else:
-                findings.append({"check": "Deploy drift", "status": "skip",
-                                 "message": "Could not get local commit time"})
+                findings.append(
+                    {
+                        "check": "Deploy drift",
+                        "status": "skip",
+                        "message": "Could not get local commit time",
+                    }
+                )
         except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
-            findings.append({"check": "Deploy drift", "status": "skip",
-                             "message": "Could not determine drift"})
+            findings.append(
+                {
+                    "check": "Deploy drift",
+                    "status": "skip",
+                    "message": "Could not determine drift",
+                }
+            )
     else:
-        findings.append({"check": "Deploy drift", "status": "skip",
-                         "message": "Not a git repository"})
+        findings.append(
+            {
+                "check": "Deploy drift",
+                "status": "skip",
+                "message": "Not a git repository",
+            }
+        )
 
     skipped = sum(1 for f in findings if f["status"] == "skip")
     effective_max = max_score - skipped
@@ -853,6 +1268,7 @@ async def doctor_project_level(workspace: str) -> dict:
 # COMBINED DOCTOR (entry point — workspace checks + both sub-doctors)
 # =============================================================================
 
+
 def _build_remediation(findings: list, wf: dict) -> tuple[list, list]:
     """Build remediation plan + verify_after from findings."""
     remediation = []
@@ -865,74 +1281,133 @@ def _build_remediation(findings: list, wf: dict) -> tuple[list, list]:
 
         check = f["check"]
         if check == "RAILWAY_TOKEN":
-            remediation.append({"intent": "Add Railway project token",
-                                "detail": "Get from Railway dashboard > Project > Settings > Tokens",
-                                "file": ".env.local", "format": "RAILWAY_TOKEN=<token>",
-                                "suggested_tool": "railguey_variable_set or manual edit"})
+            remediation.append(
+                {
+                    "intent": "Add Railway project token",
+                    "detail": "Get from Railway dashboard > Project > Settings > Tokens",
+                    "file": ".env.local",
+                    "format": "RAILWAY_TOKEN=<token>",
+                    "suggested_tool": "railguey_variable_set or manual edit",
+                }
+            )
         elif check == ".gitignore":
-            remediation.append({"intent": "Protect .env.local from git",
-                                "file": ".gitignore", "append_line": ".env.local",
-                                "suggested_tool": "Edit .gitignore"})
+            remediation.append(
+                {
+                    "intent": "Protect .env.local from git",
+                    "file": ".gitignore",
+                    "append_line": ".env.local",
+                    "suggested_tool": "Edit .gitignore",
+                }
+            )
         elif check == "CI/CD workflow":
-            remediation.append({
-                "intent": "Create deploy workflow",
-                "detail": f"Deploy to Railway on push to {default_branch}",
-                "file": ".github/workflows/deploy.yml",
-                "content": _WORKFLOW_TEMPLATE.format(branch=default_branch),
-                "github_secret": {"name": "RAILWAY_TOKEN", "source": ".env.local"},
-                "github_variable": {"name": "RAILWAY_SERVICE",
-                                    "value": service_names[0] if service_names else "<your-service-name>"},
-                "suggested_tool": "Write workflow, then gh secret set + gh variable set",
-            })
+            remediation.append(
+                {
+                    "intent": "Create deploy workflow",
+                    "detail": f"Deploy to Railway on push to {default_branch}",
+                    "file": ".github/workflows/deploy.yml",
+                    "content": _WORKFLOW_TEMPLATE.format(branch=default_branch),
+                    "github_secret": {"name": "RAILWAY_TOKEN", "source": ".env.local"},
+                    "github_variable": {
+                        "name": "RAILWAY_SERVICE",
+                        "value": service_names[0]
+                        if service_names
+                        else "<your-service-name>",
+                    },
+                    "suggested_tool": "Write workflow, then gh secret set + gh variable set",
+                }
+            )
         elif check == "GitHub repo linking":
             for svc in f.get("linked", []):
-                remediation.append({"intent": f"Unlink {svc['service']} from {svc['repo']}",
-                                    "suggested_tool": "railguey_unlink_repo"})
+                remediation.append(
+                    {
+                        "intent": f"Unlink {svc['service']} from {svc['repo']}",
+                        "suggested_tool": "railguey_unlink_repo",
+                    }
+                )
         elif check == "Token environment scope":
-            remediation.append({"intent": "Fix token environment coverage",
-                                "detail": f["message"],
-                                "suggested_tool": "railguey_account_add + railguey_account_default"})
+            remediation.append(
+                {
+                    "intent": "Fix token environment coverage",
+                    "detail": f["message"],
+                    "suggested_tool": "railguey_account_add + railguey_account_default",
+                }
+            )
         elif check == "Environment names":
-            remediation.append({"intent": "Fix workflow environment names",
-                                "detail": f["message"],
-                                "suggested_tool": "Edit --environment flags in workflow"})
+            remediation.append(
+                {
+                    "intent": "Fix workflow environment names",
+                    "detail": f["message"],
+                    "suggested_tool": "Edit --environment flags in workflow",
+                }
+            )
         elif check == ".dockerignore":
-            remediation.append({"intent": "Create or fix .dockerignore",
-                                "file": ".dockerignore",
-                                "suggested_tool": "Write .dockerignore file"})
+            remediation.append(
+                {
+                    "intent": "Create or fix .dockerignore",
+                    "file": ".dockerignore",
+                    "suggested_tool": "Write .dockerignore file",
+                }
+            )
         elif check == "Domain" or check == "Domain coverage":
-            remediation.append({"intent": "Configure domain",
-                                "detail": f["message"],
-                                "suggested_tool": "railguey_domain"})
+            remediation.append(
+                {
+                    "intent": "Configure domain",
+                    "detail": f["message"],
+                    "suggested_tool": "railguey_domain",
+                }
+            )
         elif check == "Deploy drift":
-            remediation.append({"intent": "Deploy latest code",
-                                "detail": f["message"],
-                                "suggested_tool": "railguey_deploy or git push"})
+            remediation.append(
+                {
+                    "intent": "Deploy latest code",
+                    "detail": f["message"],
+                    "suggested_tool": "railguey_deploy or git push",
+                }
+            )
         elif check == "Deployment health":
-            remediation.append({"intent": "Fix failed deployments",
-                                "detail": f["message"],
-                                "suggested_tool": "railguey_deployment_logs then railguey_redeploy"})
+            remediation.append(
+                {
+                    "intent": "Fix failed deployments",
+                    "detail": f["message"],
+                    "suggested_tool": "railguey_deployment_logs then railguey_redeploy",
+                }
+            )
         elif check == "CI/CD health":
-            remediation.append({"intent": "Fix CI/CD pipeline",
-                                "detail": f["message"],
-                                "suggested_tool": "gh run view --log"})
+            remediation.append(
+                {
+                    "intent": "Fix CI/CD pipeline",
+                    "detail": f["message"],
+                    "suggested_tool": "gh run view --log",
+                }
+            )
         elif check == "Git repository":
-            remediation.append({"intent": "Set up git remote",
-                                "suggested_tool": "gh repo create"})
+            remediation.append(
+                {"intent": "Set up git remote", "suggested_tool": "gh repo create"}
+            )
         elif check == "Local setup":
-            remediation.append({"intent": "Add lockfile",
-                                "detail": f["message"],
-                                "suggested_tool": "Run package manager install to generate lockfile"})
+            remediation.append(
+                {
+                    "intent": "Add lockfile",
+                    "detail": f["message"],
+                    "suggested_tool": "Run package manager install to generate lockfile",
+                }
+            )
 
     verify_after = []
     if remediation:
         verify_after = [
-            {"intent": "Confirm GitHub Actions deploy succeeded",
-             "suggested_tool": "gh run list --limit 1"},
-            {"intent": "Confirm Railway deployment landed",
-             "suggested_tool": "railguey_deployments"},
-            {"intent": "Re-run doctor to confirm all checks pass",
-             "suggested_tool": "railguey_doctor"},
+            {
+                "intent": "Confirm GitHub Actions deploy succeeded",
+                "suggested_tool": "gh run list --limit 1",
+            },
+            {
+                "intent": "Confirm Railway deployment landed",
+                "suggested_tool": "railguey_deployments",
+            },
+            {
+                "intent": "Re-run doctor to confirm all checks pass",
+                "suggested_tool": "railguey_doctor",
+            },
         ]
 
     return remediation, verify_after
@@ -977,6 +1452,7 @@ async def doctor(workspace: str) -> dict:
     pypi_result = None
     try:
         from railguey.lib.orchestrate import _load_all_registries, _expand_home
+
         for reg in _load_all_registries():
             for svc in reg.get("services", []):
                 if svc.get("type") != "pypi_package":
@@ -984,6 +1460,7 @@ async def doctor(workspace: str) -> dict:
                 svc_ws = _expand_home(svc.get("workspace"))
                 if svc_ws and Path(svc_ws).resolve() == ws:
                     from railguey.lib.tools import pypi_status
+
                     pypi_result = await pypi_status([svc["name"]])
                     break
             if pypi_result:
@@ -1001,17 +1478,37 @@ async def doctor(workspace: str) -> dict:
         for pkg in pypi_result["packages"]:
             status = pkg.get("status", "UNKNOWN")
             if status == "IN_SYNC":
-                all_findings.append({"check": "pypi_sync", "status": "pass",
-                                     "detail": f"PyPI {pkg.get('pypi_version')} == local {pkg.get('local_version')}"})
+                all_findings.append(
+                    {
+                        "check": "pypi_sync",
+                        "status": "pass",
+                        "detail": f"PyPI {pkg.get('pypi_version')} == local {pkg.get('local_version')}",
+                    }
+                )
             elif status == "GIT_AHEAD":
-                all_findings.append({"check": "pypi_sync", "status": "warn",
-                                     "detail": f"Local {pkg.get('local_version')} ahead of PyPI {pkg.get('pypi_version')} — publish pending?"})
+                all_findings.append(
+                    {
+                        "check": "pypi_sync",
+                        "status": "warn",
+                        "detail": f"Local {pkg.get('local_version')} ahead of PyPI {pkg.get('pypi_version')} — publish pending?",
+                    }
+                )
             elif status == "PUBLISH_FAILED":
-                all_findings.append({"check": "pypi_sync", "status": "fail",
-                                     "detail": f"Tag pushed but PyPI has {pkg.get('pypi_version')} — publish may have failed"})
+                all_findings.append(
+                    {
+                        "check": "pypi_sync",
+                        "status": "fail",
+                        "detail": f"Tag pushed but PyPI has {pkg.get('pypi_version')} — publish may have failed",
+                    }
+                )
             else:
-                all_findings.append({"check": "pypi_sync", "status": "warn",
-                                     "detail": f"PyPI status: {status}"})
+                all_findings.append(
+                    {
+                        "check": "pypi_sync",
+                        "status": "warn",
+                        "detail": f"PyPI status: {status}",
+                    }
+                )
 
     remediation, verify_after = _build_remediation(all_findings, wf)
 
@@ -1020,7 +1517,7 @@ async def doctor(workspace: str) -> dict:
     ws_effective = ws_max - ws_skipped
 
     # Overall health
-    all_healthy = (ws_score == ws_effective)
+    all_healthy = ws_score == ws_effective
     if svc_result:
         all_healthy = all_healthy and svc_result.get("healthy", False)
     if proj_result:

--- a/railguey/lib/graphql.py
+++ b/railguey/lib/graphql.py
@@ -23,7 +23,10 @@ async def _gql(token: str, query: str, variables: dict | None = None) -> dict:
             resp = await client.post(BACKBOARD_URL, headers=headers, json=payload)
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            return {"error": f"Backboard API returned {exc.response.status_code}", "body": exc.response.text}
+            return {
+                "error": f"Backboard API returned {exc.response.status_code}",
+                "body": exc.response.text,
+            }
         except httpx.RequestError as exc:
             return {"error": f"Request failed: {exc}"}
 
@@ -52,7 +55,10 @@ async def _gql_bearer(token: str, query: str, variables: dict | None = None) -> 
             resp = await client.post(BACKBOARD_URL, headers=headers, json=payload)
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            return {"error": f"Backboard API returned {exc.response.status_code}", "body": exc.response.text}
+            return {
+                "error": f"Backboard API returned {exc.response.status_code}",
+                "body": exc.response.text,
+            }
         except httpx.RequestError as exc:
             return {"error": f"Request failed: {exc}"}
 
@@ -72,6 +78,7 @@ def _load_user_token(account: str | None = None) -> str:
     4. ~/.railway/config.json (CLI fallback)
     """
     from railguey.lib.accounts import get_account_token
+
     return get_account_token(account)
 
 
@@ -83,7 +90,9 @@ async def _resolve_project(token: str) -> dict:
     return result.get("projectToken", {})
 
 
-async def _resolve_service_id(token: str, project_id: str, service_name: str) -> str | None:
+async def _resolve_service_id(
+    token: str, project_id: str, service_name: str
+) -> str | None:
     """Resolve a service name to its ID within a project."""
     query = """
     query project($id: String!) {

--- a/railguey/lib/orchestrate.py
+++ b/railguey/lib/orchestrate.py
@@ -31,7 +31,9 @@ def _load_registry() -> dict:
         if path.exists():
             with open(path) as f:
                 return yaml.safe_load(f)
-    return {"error": f"Registry not found. Searched: {[str(p) for p in _REGISTRY_PATHS]}"}
+    return {
+        "error": f"Registry not found. Searched: {[str(p) for p in _REGISTRY_PATHS]}"
+    }
 
 
 def _load_all_registries() -> list[dict]:
@@ -63,6 +65,7 @@ def _expand_home(path: str | None) -> str | None:
 
 # ── Tool 1: registry ───────────────────────────────────────────────
 
+
 async def registry(service: str | None = None) -> dict:
     """Read the service registry. Returns metadata for one or all services.
 
@@ -91,6 +94,7 @@ async def registry(service: str | None = None) -> dict:
 
 # ── Tool 2: preflight ──────────────────────────────────────────────
 
+
 async def preflight(service: str, workspace: str | None = None) -> dict:
     """Pre-push checks for a service. Returns go/no-go with reasons.
 
@@ -108,7 +112,10 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
     svc = _find_service(reg, service)
     if not svc:
         names = [s["name"] for s in reg.get("services", [])]
-        return {"go": False, "reasons": [f"Service '{service}' not in registry. Known: {names}"]}
+        return {
+            "go": False,
+            "reasons": [f"Service '{service}' not in registry. Known: {names}"],
+        }
 
     ws = workspace or _expand_home(svc.get("workspace"))
     checks = []
@@ -118,18 +125,32 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
     deploy_branch = svc.get("deploy", {}).get("branch")
     if deploy_branch and ws:
         import subprocess
+
         try:
             result = subprocess.run(
                 ["git", "branch", "--show-current"],
-                cwd=ws, capture_output=True, text=True, timeout=5,
+                cwd=ws,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             current_branch = result.stdout.strip()
             if current_branch == deploy_branch:
-                checks.append({"check": "branch", "status": "pass",
-                               "detail": f"On {current_branch}"})
+                checks.append(
+                    {
+                        "check": "branch",
+                        "status": "pass",
+                        "detail": f"On {current_branch}",
+                    }
+                )
             else:
-                blocking.append({"check": "branch", "status": "fail",
-                                 "detail": f"On '{current_branch}', registry expects '{deploy_branch}'"})
+                blocking.append(
+                    {
+                        "check": "branch",
+                        "status": "fail",
+                        "detail": f"On '{current_branch}', registry expects '{deploy_branch}'",
+                    }
+                )
         except Exception as e:
             checks.append({"check": "branch", "status": "skip", "detail": str(e)})
 
@@ -137,17 +158,28 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
     defaults = reg.get("defaults", {}).get("preflight", {})
     if defaults.get("require_clean_worktree", True) and ws:
         import subprocess
+
         try:
             result = subprocess.run(
                 ["git", "status", "--porcelain"],
-                cwd=ws, capture_output=True, text=True, timeout=5,
+                cwd=ws,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             dirty_files = [ln for ln in result.stdout.strip().split("\n") if ln.strip()]
             if not dirty_files:
-                checks.append({"check": "worktree", "status": "pass", "detail": "Clean"})
+                checks.append(
+                    {"check": "worktree", "status": "pass", "detail": "Clean"}
+                )
             else:
-                blocking.append({"check": "worktree", "status": "fail",
-                                 "detail": f"{len(dirty_files)} uncommitted files"})
+                blocking.append(
+                    {
+                        "check": "worktree",
+                        "status": "fail",
+                        "detail": f"{len(dirty_files)} uncommitted files",
+                    }
+                )
         except Exception as e:
             checks.append({"check": "worktree", "status": "skip", "detail": str(e)})
 
@@ -167,23 +199,38 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
                       }
                     }
                     """
-                    dep_result = await _gql(token, dep_query, {
-                        "input": {"projectId": project_id, "serviceId": service_id}
-                    })
+                    dep_result = await _gql(
+                        token,
+                        dep_query,
+                        {"input": {"projectId": project_id, "serviceId": service_id}},
+                    )
                     edges = dep_result.get("deployments", {}).get("edges", [])
                     if edges:
                         latest_status = edges[0]["node"].get("status", "")
                         if latest_status in ("BUILDING", "DEPLOYING", "INITIALIZING"):
-                            blocking.append({
-                                "check": "concurrency", "status": "fail",
-                                "detail": f"Deploy already in progress (status: {latest_status})"
-                            })
+                            blocking.append(
+                                {
+                                    "check": "concurrency",
+                                    "status": "fail",
+                                    "detail": f"Deploy already in progress (status: {latest_status})",
+                                }
+                            )
                         else:
-                            checks.append({"check": "concurrency", "status": "pass",
-                                           "detail": f"No active deploy (last: {latest_status})"})
+                            checks.append(
+                                {
+                                    "check": "concurrency",
+                                    "status": "pass",
+                                    "detail": f"No active deploy (last: {latest_status})",
+                                }
+                            )
                 else:
-                    checks.append({"check": "concurrency", "status": "skip",
-                                   "detail": f"Service '{service}' not found in Railway project"})
+                    checks.append(
+                        {
+                            "check": "concurrency",
+                            "status": "skip",
+                            "detail": f"Service '{service}' not found in Railway project",
+                        }
+                    )
         except Exception as e:
             checks.append({"check": "concurrency", "status": "skip", "detail": str(e)})
 
@@ -194,8 +241,13 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
         target_name = dep.get("target")
         target_svc = _find_service(reg, target_name)
         if not target_svc:
-            blocking.append({"check": f"dependency:{target_name}", "status": "fail",
-                             "detail": f"Dependency '{target_name}' not in registry"})
+            blocking.append(
+                {
+                    "check": f"dependency:{target_name}",
+                    "status": "fail",
+                    "detail": f"Dependency '{target_name}' not in registry",
+                }
+            )
             continue
 
         # For migrations: check that all are synced
@@ -203,10 +255,14 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
             target_ws = _expand_home(target_svc.get("workspace"))
             if target_ws:
                 import subprocess
+
                 try:
                     result = subprocess.run(
                         ["npx", "supabase", "migration", "list", "--linked"],
-                        cwd=target_ws, capture_output=True, text=True, timeout=30,
+                        cwd=target_ws,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
                     )
                     # Look for lines where Local has a value but Remote is empty
                     unsynced = []
@@ -216,23 +272,41 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
                         if len(parts) >= 2 and parts[0] and not parts[1]:
                             unsynced.append(parts[0])
                     if unsynced:
-                        blocking.append({
-                            "check": f"dependency:{target_name}", "status": "fail",
-                            "detail": f"Undeployed migrations: {unsynced}"
-                        })
+                        blocking.append(
+                            {
+                                "check": f"dependency:{target_name}",
+                                "status": "fail",
+                                "detail": f"Undeployed migrations: {unsynced}",
+                            }
+                        )
                     else:
-                        checks.append({"check": f"dependency:{target_name}", "status": "pass",
-                                       "detail": "All migrations synced"})
+                        checks.append(
+                            {
+                                "check": f"dependency:{target_name}",
+                                "status": "pass",
+                                "detail": "All migrations synced",
+                            }
+                        )
                 except Exception as e:
-                    checks.append({"check": f"dependency:{target_name}", "status": "skip",
-                                   "detail": str(e)})
+                    checks.append(
+                        {
+                            "check": f"dependency:{target_name}",
+                            "status": "skip",
+                            "detail": str(e),
+                        }
+                    )
 
         # For Railway services: check latest deploy is SUCCESS
         elif target_svc.get("type") == "railway_service":
             target_ws = _expand_home(target_svc.get("workspace"))
             if not target_ws:
-                blocking.append({"check": f"dependency:{target_name}", "status": "fail",
-                                 "detail": f"Required dependency '{target_name}' has no workspace configured"})
+                blocking.append(
+                    {
+                        "check": f"dependency:{target_name}",
+                        "status": "fail",
+                        "detail": f"Required dependency '{target_name}' has no workspace configured",
+                    }
+                )
             else:
                 try:
                     token = _load_token(target_ws)
@@ -248,20 +322,39 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
                               }
                             }
                             """
-                            dep_result = await _gql(token, dep_query, {
-                                "input": {"projectId": project_id, "serviceId": sid}
-                            })
+                            dep_result = await _gql(
+                                token,
+                                dep_query,
+                                {"input": {"projectId": project_id, "serviceId": sid}},
+                            )
                             edges = dep_result.get("deployments", {}).get("edges", [])
                             if edges and edges[0]["node"].get("status") == "SUCCESS":
-                                checks.append({"check": f"dependency:{target_name}", "status": "pass",
-                                               "detail": "Latest deploy SUCCESS"})
+                                checks.append(
+                                    {
+                                        "check": f"dependency:{target_name}",
+                                        "status": "pass",
+                                        "detail": "Latest deploy SUCCESS",
+                                    }
+                                )
                             else:
-                                status = edges[0]["node"].get("status") if edges else "none"
-                                blocking.append({"check": f"dependency:{target_name}", "status": "fail",
-                                                 "detail": f"Latest deploy: {status}"})
+                                status = (
+                                    edges[0]["node"].get("status") if edges else "none"
+                                )
+                                blocking.append(
+                                    {
+                                        "check": f"dependency:{target_name}",
+                                        "status": "fail",
+                                        "detail": f"Latest deploy: {status}",
+                                    }
+                                )
                 except Exception as e:
-                    checks.append({"check": f"dependency:{target_name}", "status": "skip",
-                                   "detail": str(e)})
+                    checks.append(
+                        {
+                            "check": f"dependency:{target_name}",
+                            "status": "skip",
+                            "detail": str(e),
+                        }
+                    )
 
     go = len(blocking) == 0
     return {
@@ -269,13 +362,18 @@ async def preflight(service: str, workspace: str | None = None) -> dict:
         "service": service,
         "passed": checks,
         "blocking": blocking,
-        "summary": "All preflight checks passed" if go else f"{len(blocking)} blocking issue(s)",
+        "summary": "All preflight checks passed"
+        if go
+        else f"{len(blocking)} blocking issue(s)",
     }
 
 
 # ── Tool 3: verify ─────────────────────────────────────────────────
 
-async def verify(service: str, workspace: str | None = None, deployment_id: str | None = None) -> dict:
+
+async def verify(
+    service: str, workspace: str | None = None, deployment_id: str | None = None
+) -> dict:
     """Post-push verification. Polls Railway, checks health, scans logs.
 
     Returns pass/fail with evidence.
@@ -298,17 +396,21 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
     poll_interval = defaults.get("poll_interval_seconds", 10)
     streak_target = svc_verify.get("success_streak", defaults.get("success_streak", 3))
     log_tail = defaults.get("log_tail_lines", 50)
-    fail_patterns = (
-        svc.get("health", {}).get("log_patterns", {}).get("fail_fast", [])
-        + defaults.get("fail_fast_patterns", [])
-    )
+    fail_patterns = svc.get("health", {}).get("log_patterns", {}).get(
+        "fail_fast", []
+    ) + defaults.get("fail_fast_patterns", [])
 
     results = {"service": service, "checks": []}
 
     # Skip Railway polling for non-Railway services
     if svc.get("type") != "railway_service":
-        results["checks"].append({"check": "deploy_poll", "status": "skip",
-                                   "detail": f"Not a Railway service (type: {svc.get('type')})"})
+        results["checks"].append(
+            {
+                "check": "deploy_poll",
+                "status": "skip",
+                "detail": f"Not a Railway service (type: {svc.get('type')})",
+            }
+        )
         results["pass"] = True
         return results
 
@@ -318,15 +420,22 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
         project = await _resolve_project(token)
         if "error" in project:
             results["pass"] = False
-            results["checks"].append({"check": "deploy_poll", "status": "fail", "detail": str(project)})
+            results["checks"].append(
+                {"check": "deploy_poll", "status": "fail", "detail": str(project)}
+            )
             return results
 
         project_id = project.get("projectId", "")
         service_id = await _resolve_service_id(token, project_id, service)
         if not service_id:
             results["pass"] = False
-            results["checks"].append({"check": "deploy_poll", "status": "fail",
-                                       "detail": f"Service '{service}' not found in Railway"})
+            results["checks"].append(
+                {
+                    "check": "deploy_poll",
+                    "status": "fail",
+                    "detail": f"Service '{service}' not found in Railway",
+                }
+            )
             return results
 
         dep_query = """
@@ -342,9 +451,11 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
         final_deployment_id = deployment_id
 
         while time.time() - start_time < timeout:
-            dep_result = await _gql(token, dep_query, {
-                "input": {"projectId": project_id, "serviceId": service_id}
-            })
+            dep_result = await _gql(
+                token,
+                dep_query,
+                {"input": {"projectId": project_id, "serviceId": service_id}},
+            )
             edges = dep_result.get("deployments", {}).get("edges", [])
             if edges:
                 node = edges[0]["node"]
@@ -355,18 +466,33 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
             await asyncio.sleep(poll_interval)
 
         if final_status == "SUCCESS":
-            results["checks"].append({"check": "deploy_poll", "status": "pass",
-                                       "detail": f"Deploy {final_status}",
-                                       "deployment_id": final_deployment_id})
+            results["checks"].append(
+                {
+                    "check": "deploy_poll",
+                    "status": "pass",
+                    "detail": f"Deploy {final_status}",
+                    "deployment_id": final_deployment_id,
+                }
+            )
         elif final_status:
-            results["checks"].append({"check": "deploy_poll", "status": "fail",
-                                       "detail": f"Deploy {final_status}",
-                                       "deployment_id": final_deployment_id})
+            results["checks"].append(
+                {
+                    "check": "deploy_poll",
+                    "status": "fail",
+                    "detail": f"Deploy {final_status}",
+                    "deployment_id": final_deployment_id,
+                }
+            )
             results["pass"] = False
             return results
         else:
-            results["checks"].append({"check": "deploy_poll", "status": "fail",
-                                       "detail": f"Timed out after {timeout}s"})
+            results["checks"].append(
+                {
+                    "check": "deploy_poll",
+                    "status": "fail",
+                    "detail": f"Timed out after {timeout}s",
+                }
+            )
             results["pass"] = False
             return results
 
@@ -379,29 +505,44 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
               }
             }
             """
-            log_result = await _gql(token, log_query, {
-                "deploymentId": final_deployment_id, "limit": log_tail,
-            })
+            log_result = await _gql(
+                token,
+                log_query,
+                {
+                    "deploymentId": final_deployment_id,
+                    "limit": log_tail,
+                },
+            )
             log_entries = log_result.get("deploymentLogs", [])
             found_issues = []
             for entry in log_entries:
                 msg = entry.get("message", "")
                 for pattern in fail_patterns:
                     if pattern.lower() in msg.lower():
-                        found_issues.append({"pattern": pattern, "line": msg.strip()[:200]})
+                        found_issues.append(
+                            {"pattern": pattern, "line": msg.strip()[:200]}
+                        )
                         break
 
             if found_issues:
-                results["checks"].append({
-                    "check": "log_scan", "status": "fail",
-                    "detail": f"Found {len(found_issues)} fail-fast pattern(s)",
-                    "matches": found_issues[:10],
-                })
+                results["checks"].append(
+                    {
+                        "check": "log_scan",
+                        "status": "fail",
+                        "detail": f"Found {len(found_issues)} fail-fast pattern(s)",
+                        "matches": found_issues[:10],
+                    }
+                )
                 results["pass"] = False
                 return results
             else:
-                results["checks"].append({"check": "log_scan", "status": "pass",
-                                           "detail": f"No fail-fast patterns in {len(log_entries)} log lines"})
+                results["checks"].append(
+                    {
+                        "check": "log_scan",
+                        "status": "pass",
+                        "detail": f"No fail-fast patterns in {len(log_entries)} log lines",
+                    }
+                )
 
         # Step 3: HTTP health check
         health_http = svc.get("health", {}).get("http")
@@ -422,10 +563,26 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
             """
             svc_result = await _gql(token, svc_query, {"id": service_id})
             domains = []
-            for edge in svc_result.get("service", {}).get("serviceInstances", {}).get("edges", []):
+            for edge in (
+                svc_result.get("service", {})
+                .get("serviceInstances", {})
+                .get("edges", [])
+            ):
                 dom_data = edge["node"].get("domains", {}) or {}
-                domains.extend([d["domain"] for d in dom_data.get("customDomains", []) if d.get("domain")])
-                domains.extend([d["domain"] for d in dom_data.get("serviceDomains", []) if d.get("domain")])
+                domains.extend(
+                    [
+                        d["domain"]
+                        for d in dom_data.get("customDomains", [])
+                        if d.get("domain")
+                    ]
+                )
+                domains.extend(
+                    [
+                        d["domain"]
+                        for d in dom_data.get("serviceDomains", [])
+                        if d.get("domain")
+                    ]
+                )
 
             if domains:
                 health_path = health_http.get("path", "/health")
@@ -436,7 +593,9 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
                 last_error = None
                 for _ in range(streak_target + 2):
                     try:
-                        async with httpx.AsyncClient(timeout=10, follow_redirects=True) as client:
+                        async with httpx.AsyncClient(
+                            timeout=10, follow_redirects=True
+                        ) as client:
                             resp = await client.get(url)
                             if resp.status_code == expect_status:
                                 streak += 1
@@ -444,32 +603,47 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
                                     break
                             else:
                                 streak = 0
-                                last_error = f"Got {resp.status_code}, expected {expect_status}"
+                                last_error = (
+                                    f"Got {resp.status_code}, expected {expect_status}"
+                                )
                     except Exception as e:
                         streak = 0
                         last_error = str(e)
                     await asyncio.sleep(3)
 
                 if streak >= streak_target:
-                    results["checks"].append({
-                        "check": "health_http", "status": "pass",
-                        "detail": f"{url} returned {expect_status} x{streak}",
-                    })
+                    results["checks"].append(
+                        {
+                            "check": "health_http",
+                            "status": "pass",
+                            "detail": f"{url} returned {expect_status} x{streak}",
+                        }
+                    )
                 else:
-                    results["checks"].append({
-                        "check": "health_http", "status": "fail",
-                        "detail": f"Health check failed: {last_error}",
-                        "url": url,
-                    })
+                    results["checks"].append(
+                        {
+                            "check": "health_http",
+                            "status": "fail",
+                            "detail": f"Health check failed: {last_error}",
+                            "url": url,
+                        }
+                    )
                     results["pass"] = False
                     return results
             else:
-                results["checks"].append({"check": "health_http", "status": "skip",
-                                           "detail": "No domain found on Railway service"})
+                results["checks"].append(
+                    {
+                        "check": "health_http",
+                        "status": "skip",
+                        "detail": "No domain found on Railway service",
+                    }
+                )
 
     except Exception as e:
         results["pass"] = False
-        results["checks"].append({"check": "verify", "status": "error", "detail": str(e)})
+        results["checks"].append(
+            {"check": "verify", "status": "error", "detail": str(e)}
+        )
         return results
 
     results["pass"] = True
@@ -477,6 +651,7 @@ async def verify(service: str, workspace: str | None = None, deployment_id: str 
 
 
 # ── Tool 4: deploy_plan ────────────────────────────────────────────
+
 
 async def deploy_plan(repos: list[str]) -> dict:
     """Given changed repos, return an ordered deploy plan with stages and gates.
@@ -502,8 +677,10 @@ async def deploy_plan(repos: list[str]) -> dict:
             affected.append(svc)
 
     if not affected:
-        return {"error": f"No services match repos: {repos}",
-                "known_repos": list({s.get("repo") for s in all_services if s.get("repo")})}
+        return {
+            "error": f"No services match repos: {repos}",
+            "known_repos": list({s.get("repo") for s in all_services if s.get("repo")}),
+        }
 
     affected_names = {s["name"] for s in affected}
 
@@ -556,37 +733,58 @@ async def deploy_plan(repos: list[str]) -> dict:
 
     stages = []
     if stage1:
-        stages.append({
-            "stage": 1,
-            "label": "Database migrations",
-            "gate": "blocking — must complete before proceeding",
-            "services": [{"name": s["name"], "type": s["type"],
-                          "deploy": s.get("deploy", {}),
-                          "in_change_set": s.get("repo") in repos}
-                         for s in stage1],
-        })
+        stages.append(
+            {
+                "stage": 1,
+                "label": "Database migrations",
+                "gate": "blocking — must complete before proceeding",
+                "services": [
+                    {
+                        "name": s["name"],
+                        "type": s["type"],
+                        "deploy": s.get("deploy", {}),
+                        "in_change_set": s.get("repo") in repos,
+                    }
+                    for s in stage1
+                ],
+            }
+        )
     if stage2:
-        stages.append({
-            "stage": 2,
-            "label": "API and config services",
-            "gate": "verify health before proceeding to stage 3",
-            "services": [{"name": s["name"], "type": s["type"],
-                          "deploy": s.get("deploy", {}),
-                          "in_change_set": s.get("repo") in repos}
-                         for s in stage2],
-            "parallel": len(stage2) > 1,
-        })
+        stages.append(
+            {
+                "stage": 2,
+                "label": "API and config services",
+                "gate": "verify health before proceeding to stage 3",
+                "services": [
+                    {
+                        "name": s["name"],
+                        "type": s["type"],
+                        "deploy": s.get("deploy", {}),
+                        "in_change_set": s.get("repo") in repos,
+                    }
+                    for s in stage2
+                ],
+                "parallel": len(stage2) > 1,
+            }
+        )
     if stage3:
-        stages.append({
-            "stage": len(stages) + 1,
-            "label": "Frontends and workers",
-            "gate": "final verification",
-            "services": [{"name": s["name"], "type": s["type"],
-                          "deploy": s.get("deploy", {}),
-                          "in_change_set": s.get("repo") in repos}
-                         for s in stage3],
-            "parallel": len(stage3) > 1,
-        })
+        stages.append(
+            {
+                "stage": len(stages) + 1,
+                "label": "Frontends and workers",
+                "gate": "final verification",
+                "services": [
+                    {
+                        "name": s["name"],
+                        "type": s["type"],
+                        "deploy": s.get("deploy", {}),
+                        "in_change_set": s.get("repo") in repos,
+                    }
+                    for s in stage3
+                ],
+                "parallel": len(stage3) > 1,
+            }
+        )
 
     # Identify services added by dependency expansion (not in original change set)
     auto_included = expanded - affected_names
@@ -600,5 +798,7 @@ async def deploy_plan(repos: list[str]) -> dict:
         "warnings": [
             f"'{name}' auto-included as required dependency (not in your change set)"
             for name in sorted(auto_included)
-        ] if auto_included else [],
+        ]
+        if auto_included
+        else [],
     }

--- a/railguey/lib/token.py
+++ b/railguey/lib/token.py
@@ -21,6 +21,7 @@ def _load_token(workspace: str) -> str:
     # 1. Account system override
     try:
         from railguey.lib.accounts import get_account_token
+
         return get_account_token()
     except (ValueError, ImportError):
         pass

--- a/railguey/lib/tools.py
+++ b/railguey/lib/tools.py
@@ -13,7 +13,11 @@ from pathlib import Path
 
 from railguey.lib.token import _load_token
 from railguey.lib.graphql import (
-    _gql, _gql_bearer, _resolve_project, _resolve_service_id, _load_user_token,
+    _gql,
+    _gql_bearer,
+    _resolve_project,
+    _resolve_service_id,
+    _load_user_token,
 )
 from railguey.lib.doctor import doctor  # re-export
 
@@ -85,17 +89,18 @@ async def status(workspace: str) -> dict:
                 continue  # only show the token's environment
             latest = inst.get("latestDeployment") or {}
             domains_data = inst.get("domains", {}) or {}
-            all_domains = (
-                [d.get("domain", "") for d in domains_data.get("serviceDomains", [])]
-                + [d.get("domain", "") for d in domains_data.get("customDomains", [])]
+            all_domains = [
+                d.get("domain", "") for d in domains_data.get("serviceDomains", [])
+            ] + [d.get("domain", "") for d in domains_data.get("customDomains", [])]
+            services_out.append(
+                {
+                    "name": svc.get("name", "unknown"),
+                    "serviceId": svc.get("id", ""),
+                    "status": latest.get("status", "no deploys"),
+                    "deployedAt": latest.get("createdAt", ""),
+                    "domains": [d for d in all_domains if d],
+                }
             )
-            services_out.append({
-                "name": svc.get("name", "unknown"),
-                "serviceId": svc.get("id", ""),
-                "status": latest.get("status", "no deploys"),
-                "deployedAt": latest.get("createdAt", ""),
-                "domains": [d for d in all_domains if d],
-            })
 
     return {
         "project": proj.get("name", "unknown"),
@@ -150,7 +155,10 @@ async def pypi_status(packages: list[str] | None = None) -> dict:
             try:
                 result = subprocess.run(
                     ["git", "describe", "--tags", "--abbrev=0"],
-                    cwd=ws, capture_output=True, text=True, timeout=5,
+                    cwd=ws,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
                 )
                 if result.returncode == 0:
                     entry["latest_tag"] = result.stdout.strip()
@@ -217,9 +225,9 @@ async def logs(
       }
     }
     """
-    dep_result = await _gql(token, dep_query, {
-        "input": {"projectId": project_id, "serviceId": service_id}
-    })
+    dep_result = await _gql(
+        token, dep_query, {"input": {"projectId": project_id, "serviceId": service_id}}
+    )
     if "error" in dep_result:
         return dep_result
     edges = dep_result.get("deployments", {}).get("edges", [])
@@ -287,10 +295,14 @@ async def deploy(workspace: str, service: str) -> dict:
       serviceInstanceRedeploy(environmentId: $environmentId, serviceId: $serviceId)
     }
     """
-    result = await _gql(token, query, {
-        "environmentId": environment_id,
-        "serviceId": service_id,
-    })
+    result = await _gql(
+        token,
+        query,
+        {
+            "environmentId": environment_id,
+            "serviceId": service_id,
+        },
+    )
     if "error" in result:
         return result
     return {"deployed": True, "service": service}
@@ -319,11 +331,15 @@ async def variables(workspace: str, service: str) -> dict:
       variables(environmentId: $environmentId, projectId: $projectId, serviceId: $serviceId)
     }
     """
-    result = await _gql(token, query, {
-        "environmentId": environment_id,
-        "projectId": project_id,
-        "serviceId": service_id,
-    })
+    result = await _gql(
+        token,
+        query,
+        {
+            "environmentId": environment_id,
+            "projectId": project_id,
+            "serviceId": service_id,
+        },
+    )
     if "error" in result:
         return result
     return {"variables": result.get("variables", {}), "service": service}
@@ -352,15 +368,19 @@ async def variable_set(workspace: str, service: str, key: str, value: str) -> di
       variableUpsert(input: $input)
     }
     """
-    result = await _gql(token, query, {
-        "input": {
-            "environmentId": environment_id,
-            "projectId": project_id,
-            "serviceId": service_id,
-            "name": key,
-            "value": value,
-        }
-    })
+    result = await _gql(
+        token,
+        query,
+        {
+            "input": {
+                "environmentId": environment_id,
+                "projectId": project_id,
+                "serviceId": service_id,
+                "name": key,
+                "value": value,
+            }
+        },
+    )
     if "error" in result:
         return result
     return {"set": True, "key": key, "service": service}
@@ -420,9 +440,9 @@ async def redeploy(workspace: str, service: str) -> dict:
       }
     }
     """
-    dep_result = await _gql(token, dep_query, {
-        "input": {"projectId": project_id, "serviceId": service_id}
-    })
+    dep_result = await _gql(
+        token, dep_query, {"input": {"projectId": project_id, "serviceId": service_id}}
+    )
     if "error" in dep_result:
         return dep_result
     edges = dep_result.get("deployments", {}).get("edges", [])
@@ -473,9 +493,9 @@ async def restart(workspace: str, service: str) -> dict:
       }
     }
     """
-    dep_result = await _gql(token, dep_query, {
-        "input": {"projectId": project_id, "serviceId": service_id}
-    })
+    dep_result = await _gql(
+        token, dep_query, {"input": {"projectId": project_id, "serviceId": service_id}}
+    )
     if "error" in dep_result:
         return dep_result
     edges = dep_result.get("deployments", {}).get("edges", [])
@@ -539,7 +559,11 @@ async def domain(
             }
         # Update the target port on the existing domain
         return await _update_domain_port(
-            existing, service_id, environment_id, service, port,
+            existing,
+            service_id,
+            environment_id,
+            service,
+            port,
         )
 
     # Domain does not exist — create it
@@ -608,10 +632,14 @@ async def _find_existing_domain(
       }
     }
     """
-    result = await _gql(token, query, {
-        "serviceId": service_id,
-        "environmentId": environment_id,
-    })
+    result = await _gql(
+        token,
+        query,
+        {
+            "serviceId": service_id,
+            "environmentId": environment_id,
+        },
+    )
     if "error" in result:
         return None
 
@@ -713,9 +741,9 @@ async def environment_create(workspace: str, name: str) -> dict:
       environmentCreate(input: $input) { id name }
     }
     """
-    result = await _gql(token, query, {
-        "input": {"name": name, "projectId": project_id}
-    })
+    result = await _gql(
+        token, query, {"input": {"name": name, "projectId": project_id}}
+    )
     if "error" in result:
         return result
     env = result.get("environmentCreate", {})
@@ -815,10 +843,14 @@ async def service_info(workspace: str, service: str) -> dict:
       }
     }
     """
-    result = await _gql(token, query, {
-        "serviceId": service_id,
-        "environmentId": environment_id,
-    })
+    result = await _gql(
+        token,
+        query,
+        {
+            "serviceId": service_id,
+            "environmentId": environment_id,
+        },
+    )
     if "error" in result:
         return result
     return result.get("serviceInstance", {})
@@ -851,9 +883,11 @@ async def http_logs(
           }
         }
         """
-        dep_result = await _gql(token, dep_query, {
-            "input": {"projectId": project_id, "serviceId": service_id}
-        })
+        dep_result = await _gql(
+            token,
+            dep_query,
+            {"input": {"projectId": project_id, "serviceId": service_id}},
+        )
         if "error" in dep_result:
             return dep_result
         edges = dep_result.get("deployments", {}).get("edges", [])
@@ -878,7 +912,11 @@ async def http_logs(
     if "error" in result:
         return result
     log_entries = result.get("httpLogs", [])
-    return {"logs": log_entries, "count": len(log_entries), "deployment_id": deployment_id}
+    return {
+        "logs": log_entries,
+        "count": len(log_entries),
+        "deployment_id": deployment_id,
+    }
 
 
 async def deployment_logs(
@@ -1044,8 +1082,8 @@ async def project_create(
     if not team_id:
         return {
             "error": "team_id is required. Use railguey_workspaces to list available "
-                     "teams, then pass the team ID. Railguey never creates projects "
-                     "without an explicit team to prevent accidental personal-account deploys."
+            "teams, then pass the team ID. Railguey never creates projects "
+            "without an explicit team to prevent accidental personal-account deploys."
         }
 
     user_token = _load_user_token(account)
@@ -1060,9 +1098,9 @@ async def project_create(
       }
     }
     """
-    result = await _gql_bearer(user_token, create_query, {
-        "input": {"name": name, "workspaceId": team_id}
-    })
+    result = await _gql_bearer(
+        user_token, create_query, {"input": {"name": name, "workspaceId": team_id}}
+    )
     if "error" in result:
         return result
 
@@ -1081,13 +1119,17 @@ async def project_create(
       projectTokenCreate(input: $input)
     }
     """
-    token_result = await _gql_bearer(user_token, token_query, {
-        "input": {
-            "projectId": project_id,
-            "environmentId": env_id,
-            "name": f"railguey-{name}",
-        }
-    })
+    token_result = await _gql_bearer(
+        user_token,
+        token_query,
+        {
+            "input": {
+                "projectId": project_id,
+                "environmentId": env_id,
+                "name": f"railguey-{name}",
+            }
+        },
+    )
     project_token = ""
     if "error" not in token_result:
         project_token = token_result.get("projectTokenCreate", "")
@@ -1107,7 +1149,8 @@ async def project_create(
         "teamId": team_id,
         "environmentId": env_id,
         "environmentName": env_name,
-        "projectToken": project_token or "(failed to create — create manually in Railway dashboard)",
+        "projectToken": project_token
+        or "(failed to create — create manually in Railway dashboard)",
         "envLocalWritten": env_local_written,
         "workspace": workspace or "(not specified)",
     }
@@ -1136,9 +1179,9 @@ async def service_create(
       serviceCreate(input: $input) { id name }
     }
     """
-    result = await _gql(token, query, {
-        "input": {"name": name, "projectId": project_id}
-    })
+    result = await _gql(
+        token, query, {"input": {"name": name, "projectId": project_id}}
+    )
     if "error" in result:
         return result
 
@@ -1177,7 +1220,11 @@ async def list_projects(
     ws = result.get("workspace", {})
     edges = ws.get("projects", {}).get("edges", [])
     projects = [
-        {"id": e["node"]["id"], "name": e["node"]["name"], "updatedAt": e["node"].get("updatedAt", "")}
+        {
+            "id": e["node"]["id"],
+            "name": e["node"]["name"],
+            "updatedAt": e["node"].get("updatedAt", ""),
+        }
         for e in edges
     ]
     return {"workspace": ws.get("name", ""), "teamId": team_id, "projects": projects}
@@ -1223,11 +1270,17 @@ async def project_transfer(
       projectTransferToTeam(id: $id, teamId: $teamId) { id name }
     }
     """
-    result = await _gql_bearer(user_token, query, {"id": project_id, "teamId": target_team_id})
+    result = await _gql_bearer(
+        user_token, query, {"id": project_id, "teamId": target_team_id}
+    )
     if "error" in result:
         return result
     proj = result.get("projectTransferToTeam", {})
-    return {"transferred": True, "projectId": proj.get("id", project_id), "targetTeamId": target_team_id}
+    return {
+        "transferred": True,
+        "projectId": proj.get("id", project_id),
+        "targetTeamId": target_team_id,
+    }
 
 
 async def service_update(
@@ -1287,7 +1340,9 @@ async def service_update(
             gql_input[camel] = val
 
     if not gql_input:
-        return {"error": "No fields to update. Provide at least one field (healthcheck_path, start_command, etc.)."}
+        return {
+            "error": "No fields to update. Provide at least one field (healthcheck_path, start_command, etc.)."
+        }
 
     # Step 1: Use project token to resolve IDs
     token = _load_token(workspace)
@@ -1321,11 +1376,15 @@ async def service_update(
       serviceInstanceUpdate(serviceId: $serviceId, environmentId: $environmentId, input: $input)
     }
     """
-    result = await _gql_bearer(user_token, query, {
-        "serviceId": service_id,
-        "environmentId": environment_id,
-        "input": gql_input,
-    })
+    result = await _gql_bearer(
+        user_token,
+        query,
+        {
+            "serviceId": service_id,
+            "environmentId": environment_id,
+            "input": gql_input,
+        },
+    )
     if "error" in result:
         return result
 
@@ -1370,14 +1429,18 @@ async def volume_create(
       volumeCreate(input: $input) { id name createdAt }
     }
     """
-    result = await _gql(token, query, {
-        "input": {
-            "projectId": project_id,
-            "serviceId": service_id,
-            "environmentId": environment_id,
-            "mountPath": mount_path,
-        }
-    })
+    result = await _gql(
+        token,
+        query,
+        {
+            "input": {
+                "projectId": project_id,
+                "serviceId": service_id,
+                "environmentId": environment_id,
+                "mountPath": mount_path,
+            }
+        },
+    )
     if "error" in result:
         return result
 
@@ -1446,12 +1509,14 @@ async def volumes(workspace: str) -> dict:
             inst_edge.get("node", {})
             for inst_edge in node.get("volumeInstances", {}).get("edges", [])
         ]
-        out.append({
-            "id": node.get("id", ""),
-            "name": node.get("name", ""),
-            "createdAt": node.get("createdAt", ""),
-            "instances": instances,
-        })
+        out.append(
+            {
+                "id": node.get("id", ""),
+                "name": node.get("name", ""),
+                "createdAt": node.get("createdAt", ""),
+                "instances": instances,
+            }
+        )
     return {"count": len(out), "volumes": out}
 
 
@@ -1496,21 +1561,46 @@ async def volume_resize(
       volumeInstanceUpdate(volumeInstanceId: $volumeInstanceId, input: $input)
     }
     """
-    result = await _gql(token, query, {
-        "volumeInstanceId": volume_instance_id,
-        "input": {"sizeMB": size_mb},
-    })
+    result = await _gql(
+        token,
+        query,
+        {
+            "volumeInstanceId": volume_instance_id,
+            "input": {"sizeMB": size_mb},
+        },
+    )
     if "error" in result:
         return result
     return {"resized": True, "volumeInstanceId": volume_instance_id, "sizeMB": size_mb}
 
 
 __all__ = [
-    "status", "logs", "deploy", "variables", "variable_set", "services",
-    "redeploy", "restart", "domain", "environment_create", "deployments",
-    "rollback", "service_info", "http_logs", "deployment_logs",
-    "unlink_repo", "doctor", "project_create", "service_create",
-    "list_workspaces", "list_projects", "project_delete", "project_transfer",
+    "status",
+    "logs",
+    "deploy",
+    "variables",
+    "variable_set",
+    "services",
+    "redeploy",
+    "restart",
+    "domain",
+    "environment_create",
+    "deployments",
+    "rollback",
+    "service_info",
+    "http_logs",
+    "deployment_logs",
+    "unlink_repo",
+    "doctor",
+    "project_create",
+    "service_create",
+    "list_workspaces",
+    "list_projects",
+    "project_delete",
+    "project_transfer",
     "service_update",
-    "volume_create", "volumes", "volume_delete", "volume_resize",
+    "volume_create",
+    "volumes",
+    "volume_delete",
+    "volume_resize",
 ]

--- a/railguey/lib/tools.py
+++ b/railguey/lib/tools.py
@@ -1337,6 +1337,174 @@ async def service_update(
     }
 
 
+async def volume_create(
+    workspace: str,
+    service: str,
+    mount_path: str,
+) -> dict:
+    """Create a Railway volume and attach it to a service.
+
+    Uses the project-scoped token from workspace/.env.local. Confirmed
+    2026-04-15 that project tokens can execute volumeCreate — no account
+    token required (unlike serviceInstanceUpdate). Railway names the
+    volume `<service>-volume` automatically; default size is 50 GB.
+
+    After creation the service redeploys automatically with the volume
+    mounted at `mount_path`.
+    """
+    token = _load_token(workspace)
+    project = await _resolve_project(token)
+    if "error" in project:
+        return project
+    project_id = project.get("projectId")
+    environment_id = project.get("environmentId")
+    if not project_id or not environment_id:
+        return {"error": "Could not resolve projectId/environmentId from token"}
+
+    service_id = await _resolve_service_id(token, project_id, service)
+    if not service_id:
+        return {"error": f"Service '{service}' not found in project"}
+
+    query = """
+    mutation volumeCreate($input: VolumeCreateInput!) {
+      volumeCreate(input: $input) { id name createdAt }
+    }
+    """
+    result = await _gql(token, query, {
+        "input": {
+            "projectId": project_id,
+            "serviceId": service_id,
+            "environmentId": environment_id,
+            "mountPath": mount_path,
+        }
+    })
+    if "error" in result:
+        return result
+
+    vol = result.get("volumeCreate", {})
+    return {
+        "created": True,
+        "volumeId": vol.get("id", ""),
+        "volumeName": vol.get("name", ""),
+        "mountPath": mount_path,
+        "service": service,
+        "serviceId": service_id,
+        "createdAt": vol.get("createdAt", ""),
+    }
+
+
+async def volumes(workspace: str) -> dict:
+    """List all volumes in the Railway project with their mount state.
+
+    Returns each volume with its volume instances (one per environment).
+    """
+    token = _load_token(workspace)
+    project = await _resolve_project(token)
+    if "error" in project:
+        return project
+    project_id = project.get("projectId")
+    if not project_id:
+        return {"error": "Could not resolve projectId from token"}
+
+    query = """
+    query project($id: String!) {
+      project(id: $id) {
+        volumes {
+          edges {
+            node {
+              id
+              name
+              createdAt
+              volumeInstances {
+                edges {
+                  node {
+                    id
+                    mountPath
+                    sizeMB
+                    state
+                    environmentId
+                    serviceId
+                    region
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    result = await _gql(token, query, {"id": project_id})
+    if "error" in result:
+        return result
+
+    out = []
+    edges = result.get("project", {}).get("volumes", {}).get("edges", [])
+    for edge in edges:
+        node = edge.get("node", {})
+        instances = [
+            inst_edge.get("node", {})
+            for inst_edge in node.get("volumeInstances", {}).get("edges", [])
+        ]
+        out.append({
+            "id": node.get("id", ""),
+            "name": node.get("name", ""),
+            "createdAt": node.get("createdAt", ""),
+            "instances": instances,
+        })
+    return {"count": len(out), "volumes": out}
+
+
+async def volume_delete(
+    workspace: str,
+    volume_id: str,
+) -> dict:
+    """Delete a Railway volume. Irreversible — all data on the volume is lost.
+
+    Matches the existing project_delete pattern (no TOTP gate at the library
+    layer; the destructive nature is documented in the tool docstring).
+    """
+    token = _load_token(workspace)
+    query = """
+    mutation volumeDelete($volumeId: String!) {
+      volumeDelete(volumeId: $volumeId)
+    }
+    """
+    result = await _gql(token, query, {"volumeId": volume_id})
+    if "error" in result:
+        return result
+    return {"deleted": True, "volumeId": volume_id}
+
+
+async def volume_resize(
+    workspace: str,
+    volume_instance_id: str,
+    size_mb: int,
+) -> dict:
+    """Resize a volume instance to a new size (MB). Railway requires
+    grow-only — you can increase but not shrink."""
+    token = _load_token(workspace)
+    project = await _resolve_project(token)
+    if "error" in project:
+        return project
+    environment_id = project.get("environmentId")
+    if not environment_id:
+        return {"error": "Could not resolve environmentId from token"}
+
+    query = """
+    mutation volumeInstanceUpdate($volumeInstanceId: String!, $input: VolumeInstanceUpdateInput!) {
+      volumeInstanceUpdate(volumeInstanceId: $volumeInstanceId, input: $input)
+    }
+    """
+    result = await _gql(token, query, {
+        "volumeInstanceId": volume_instance_id,
+        "input": {"sizeMB": size_mb},
+    })
+    if "error" in result:
+        return result
+    return {"resized": True, "volumeInstanceId": volume_instance_id, "sizeMB": size_mb}
+
+
 __all__ = [
     "status", "logs", "deploy", "variables", "variable_set", "services",
     "redeploy", "restart", "domain", "environment_create", "deployments",
@@ -1344,4 +1512,5 @@ __all__ = [
     "unlink_repo", "doctor", "project_create", "service_create",
     "list_workspaces", "list_projects", "project_delete", "project_transfer",
     "service_update",
+    "volume_create", "volumes", "volume_delete", "volume_resize",
 ]

--- a/railguey/lib/totp.py
+++ b/railguey/lib/totp.py
@@ -73,6 +73,7 @@ def _ascii_qr(data: str) -> str:
     """Generate a compact ASCII QR code using block characters."""
     try:
         import qrcode
+
         qr = qrcode.QRCode(box_size=1, border=1)
         qr.add_data(data)
         qr.make(fit=True)
@@ -185,13 +186,13 @@ def require_totp(code: str | None) -> dict | None:
     if not secret:
         return {
             "error": "TOTP not configured. Destructive operations require TOTP. "
-                     "Run railguey_totp_setup to configure."
+            "Run railguey_totp_setup to configure."
         }
 
     if not code:
         return {
             "error": "TOTP code required for this operation. "
-                     "Provide the current 6-digit code from your authenticator app."
+            "Provide the current 6-digit code from your authenticator app."
         }
 
     result = verify(code)

--- a/railguey/mcp.py
+++ b/railguey/mcp.py
@@ -652,5 +652,78 @@ async def railguey_deploy_plan(repos: list[str]) -> dict:
     return await orchestrate.deploy_plan(repos)
 
 
+@mcp.tool()
+async def railguey_volume_create(
+    workspace: str,
+    service: str,
+    mount_path: str,
+) -> dict:
+    """Create a Railway volume and attach it to a service.
+
+    Uses the project-scoped token. Confirmed 2026-04-15 that project
+    tokens CAN execute volumeCreate — this was a known unknown before.
+    Railway auto-names the volume `<service>-volume` and defaults to
+    50 GB. The service redeploys automatically once the volume is
+    attached and mounted at `mount_path`.
+
+    Args:
+        workspace: Absolute path to project directory with .env.local.
+        service: Railway service name to attach the volume to.
+        mount_path: Path inside the container where the volume mounts
+                    (e.g. "/data", "/var/lib/sqlite").
+    """
+    return await tools.volume_create(workspace, service, mount_path)
+
+
+@mcp.tool()
+async def railguey_volumes(workspace: str) -> dict:
+    """List all volumes in the Railway project.
+
+    Returns each volume with its volume instances (one per environment
+    the volume is deployed to), including mount path, size in MB,
+    state, service binding, and region.
+
+    Args:
+        workspace: Absolute path to project directory with .env.local.
+    """
+    return await tools.volumes(workspace)
+
+
+@mcp.tool()
+async def railguey_volume_delete(
+    workspace: str,
+    volume_id: str,
+) -> dict:
+    """Delete a Railway volume. Irreversible — all data on the volume is lost.
+
+    Use railguey_volumes first to find the volume ID.
+
+    Args:
+        workspace: Absolute path to project directory with .env.local.
+        volume_id: The volume ID from railguey_volumes.
+    """
+    return await tools.volume_delete(workspace, volume_id)
+
+
+@mcp.tool()
+async def railguey_volume_resize(
+    workspace: str,
+    volume_instance_id: str,
+    size_mb: int,
+) -> dict:
+    """Resize a volume instance to a new size in MB. Grow-only — Railway
+    does not allow shrinking a volume.
+
+    Use railguey_volumes first to find the volume instance ID (each
+    volume has one instance per environment it's deployed to).
+
+    Args:
+        workspace: Absolute path to project directory with .env.local.
+        volume_instance_id: The volume instance ID from railguey_volumes.
+        size_mb: New size in megabytes. Must be larger than current size.
+    """
+    return await tools.volume_resize(workspace, volume_instance_id, size_mb)
+
+
 if __name__ == "__main__":
     mcp.run()

--- a/railguey/mcp.py
+++ b/railguey/mcp.py
@@ -298,11 +298,14 @@ async def railguey_doctor(workspace: str) -> dict:
         workspace: Absolute path to project directory to audit.
     """
     from railguey.lib.doctor import doctor
+
     return await doctor(workspace)
 
 
 @mcp.tool()
-async def railguey_doctor_service_level(workspace: str, service: str | None = None) -> dict:
+async def railguey_doctor_service_level(
+    workspace: str, service: str | None = None
+) -> dict:
     """Check a single service's Railway deployment health.
 
     Checks:
@@ -319,6 +322,7 @@ async def railguey_doctor_service_level(workspace: str, service: str | None = No
         service: Service name (auto-detected if omitted).
     """
     from railguey.lib.doctor import doctor_service_level
+
     return await doctor_service_level(workspace, service)
 
 
@@ -339,11 +343,14 @@ async def railguey_doctor_project_level(workspace: str) -> dict:
         workspace: Absolute path to project directory (for token).
     """
     from railguey.lib.doctor import doctor_project_level
+
     return await doctor_project_level(workspace)
 
 
 @mcp.tool()
-async def railguey_account_add(name: str, token: str, email: Optional[str] = None) -> dict:
+async def railguey_account_add(
+    name: str, token: str, email: Optional[str] = None
+) -> dict:
     """Register a Railway account token for multi-account support.
 
     Store tokens from multiple Railway accounts. Each gets a name you
@@ -545,7 +552,8 @@ async def railguey_service_update(
         restart_policy_max_retries: Max restart retries (used with ON_FAILURE).
     """
     return await tools.service_update(
-        workspace, service,
+        workspace,
+        service,
         healthcheck_path=healthcheck_path,
         start_command=start_command,
         build_command=build_command,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from tests.helpers import write_file
 # Isolate tests from the host account system (~/.railguey/accounts.json)
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def _no_account_system():
     """Prevent tests from reading the real ~/.railguey/accounts.json."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,10 +106,23 @@ class TestCLI:
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0
         expected = [
-            "status", "logs", "deploy", "redeploy", "restart",
-            "variables", "variable-set", "domain", "deployments",
-            "rollback", "service-info", "http-logs", "deployment-logs",
-            "unlink-repo", "environment-create", "doctor", "serve",
+            "status",
+            "logs",
+            "deploy",
+            "redeploy",
+            "restart",
+            "variables",
+            "variable-set",
+            "domain",
+            "deployments",
+            "rollback",
+            "service-info",
+            "http-logs",
+            "deployment-logs",
+            "unlink-repo",
+            "environment-create",
+            "doctor",
+            "serve",
         ]
         for cmd in expected:
             assert cmd in result.output, f"Missing command: {cmd}"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -19,19 +19,22 @@ class TestParseWorkflowDetails:
 
     def test_single_branch_single_env(self, tmp_path):
         wf_dir = tmp_path / ".github" / "workflows"
-        write_file(wf_dir / "deploy.yml", (
-            "name: Deploy\n"
-            "on:\n"
-            "  push:\n"
-            "    branches: [main]\n"
-            "jobs:\n"
-            "  deploy:\n"
-            "    runs-on: ubuntu-latest\n"
-            "    steps:\n"
-            "      - run: railway up --service cerebro --environment production --detach\n"
-            "        env:\n"
-            "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
-        ))
+        write_file(
+            wf_dir / "deploy.yml",
+            (
+                "name: Deploy\n"
+                "on:\n"
+                "  push:\n"
+                "    branches: [main]\n"
+                "jobs:\n"
+                "  deploy:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - run: railway up --service cerebro --environment production --detach\n"
+                "        env:\n"
+                "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
+            ),
+        )
         result = _parse_workflow_details(wf_dir)
         assert result["found"] is True
         assert result["branches"] == ["main"]
@@ -40,24 +43,27 @@ class TestParseWorkflowDetails:
 
     def test_multi_branch_multi_env(self, tmp_path):
         wf_dir = tmp_path / ".github" / "workflows"
-        write_file(wf_dir / "deploy.yml", (
-            "name: Deploy\n"
-            "on:\n"
-            "  push:\n"
-            "    branches: [main, develop]\n"
-            "jobs:\n"
-            "  deploy:\n"
-            "    runs-on: ubuntu-latest\n"
-            "    steps:\n"
-            "      - run: |\n"
-            "          if [ branch = main ]; then\n"
-            "            railway up --service cerebro --environment production --detach\n"
-            "          else\n"
-            "            railway up --service cerebro --environment develop --detach\n"
-            "          fi\n"
-            "        env:\n"
-            "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
-        ))
+        write_file(
+            wf_dir / "deploy.yml",
+            (
+                "name: Deploy\n"
+                "on:\n"
+                "  push:\n"
+                "    branches: [main, develop]\n"
+                "jobs:\n"
+                "  deploy:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - run: |\n"
+                "          if [ branch = main ]; then\n"
+                "            railway up --service cerebro --environment production --detach\n"
+                "          else\n"
+                "            railway up --service cerebro --environment develop --detach\n"
+                "          fi\n"
+                "        env:\n"
+                "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
+            ),
+        )
         result = _parse_workflow_details(wf_dir)
         assert result["found"] is True
         assert sorted(result["branches"]) == ["develop", "main"]
@@ -67,21 +73,24 @@ class TestParseWorkflowDetails:
     def test_single_branch_but_multi_env_detected(self, tmp_path):
         """Workflow targets 2 environments but only triggers on 1 branch."""
         wf_dir = tmp_path / ".github" / "workflows"
-        write_file(wf_dir / "deploy.yml", (
-            "name: Deploy\n"
-            "on:\n"
-            "  push:\n"
-            "    branches: [main]\n"
-            "jobs:\n"
-            "  deploy:\n"
-            "    runs-on: ubuntu-latest\n"
-            "    steps:\n"
-            "      - run: |\n"
-            "          railway up --service cerebro --environment production --detach\n"
-            "          railway up --service cerebro --environment develop --detach\n"
-            "        env:\n"
-            "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
-        ))
+        write_file(
+            wf_dir / "deploy.yml",
+            (
+                "name: Deploy\n"
+                "on:\n"
+                "  push:\n"
+                "    branches: [main]\n"
+                "jobs:\n"
+                "  deploy:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - run: |\n"
+                "          railway up --service cerebro --environment production --detach\n"
+                "          railway up --service cerebro --environment develop --detach\n"
+                "        env:\n"
+                "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
+            ),
+        )
         result = _parse_workflow_details(wf_dir)
         assert result["branches"] == ["main"]
         assert result["environments"] == ["develop", "production"]
@@ -89,19 +98,22 @@ class TestParseWorkflowDetails:
     def test_no_environment_flag(self, tmp_path):
         """Workflow without --environment is a simple single-env setup."""
         wf_dir = tmp_path / ".github" / "workflows"
-        write_file(wf_dir / "deploy.yml", (
-            "name: Deploy\n"
-            "on:\n"
-            "  push:\n"
-            "    branches: [main]\n"
-            "jobs:\n"
-            "  deploy:\n"
-            "    runs-on: ubuntu-latest\n"
-            "    steps:\n"
-            "      - run: railway up --service web --detach\n"
-            "        env:\n"
-            "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
-        ))
+        write_file(
+            wf_dir / "deploy.yml",
+            (
+                "name: Deploy\n"
+                "on:\n"
+                "  push:\n"
+                "    branches: [main]\n"
+                "jobs:\n"
+                "  deploy:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - run: railway up --service web --detach\n"
+                "        env:\n"
+                "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n"
+            ),
+        )
         result = _parse_workflow_details(wf_dir)
         assert result["found"] is True
         assert result["environments"] == []
@@ -131,14 +143,10 @@ def _mock_project_and_envs(token_env_name="production"):
                     for eid, ename in env_map.items()
                 ]
             },
-            "services": {
-                "edges": [{"node": {"id": "svc-1", "name": "cerebro"}}]
-            },
+            "services": {"edges": [{"node": {"id": "svc-1", "name": "cerebro"}}]},
         }
     }
-    gql_service = {
-        "service": {"id": "svc-1", "name": "cerebro", "repoTriggers": []}
-    }
+    gql_service = {"service": {"id": "svc-1", "name": "cerebro", "repoTriggers": []}}
     return project_return, [gql_project, gql_service]
 
 
@@ -152,7 +160,9 @@ class TestDoctor:
 
     @pytest.mark.asyncio
     async def test_token_present_passes(self, workspace_with_token):
-        with patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj:
+        with patch(
+            "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+        ) as mock_proj:
             mock_proj.return_value = {"error": "skip"}
             result = await doctor(str(workspace_with_token))
         checks = {f["check"]: f for f in result["workspace"]["findings"]}
@@ -160,7 +170,9 @@ class TestDoctor:
 
     @pytest.mark.asyncio
     async def test_gitignore_missing_warns(self, workspace_with_token):
-        with patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj:
+        with patch(
+            "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+        ) as mock_proj:
             mock_proj.return_value = {"error": "skip"}
             result = await doctor(str(workspace_with_token))
         checks = {f["check"]: f for f in result["workspace"]["findings"]}
@@ -169,16 +181,22 @@ class TestDoctor:
     @pytest.mark.asyncio
     async def test_gitignore_with_env_local_passes(self, workspace_with_token):
         write_file(workspace_with_token / ".gitignore", "node_modules/\n.env.local\n")
-        with patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj:
+        with patch(
+            "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+        ) as mock_proj:
             mock_proj.return_value = {"error": "skip"}
             result = await doctor(str(workspace_with_token))
         checks = {f["check"]: f for f in result["workspace"]["findings"]}
         assert checks[".gitignore"]["status"] == "pass"
 
-    @pytest.mark.xfail(reason="Pre-existing: doctor result structure changed to nested workspace/service/project")
+    @pytest.mark.xfail(
+        reason="Pre-existing: doctor result structure changed to nested workspace/service/project"
+    )
     @pytest.mark.asyncio
     async def test_deploy_workflow_detected(self, workspace_healthy):
-        with patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj:
+        with patch(
+            "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+        ) as mock_proj:
             mock_proj.return_value = {"error": "skip"}
             result = await doctor(str(workspace_healthy))
         checks = {f["check"]: f for f in result["workspace"]["findings"]}
@@ -187,33 +205,47 @@ class TestDoctor:
     @pytest.mark.asyncio
     async def test_no_deploy_workflow_warns(self, workspace_with_token):
         write_file(workspace_with_token / ".gitignore", ".env.local\n")
-        with patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj:
+        with patch(
+            "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+        ) as mock_proj:
             mock_proj.return_value = {"error": "skip"}
             result = await doctor(str(workspace_with_token))
         checks = {f["check"]: f for f in result["workspace"]["findings"]}
         assert checks["CI/CD workflow"]["status"] == "warn"
 
-    @pytest.mark.xfail(reason="Pre-existing: doctor result structure changed to nested workspace/service/project")
+    @pytest.mark.xfail(
+        reason="Pre-existing: doctor result structure changed to nested workspace/service/project"
+    )
     @pytest.mark.asyncio
     async def test_perfect_score_single_env(self, workspace_healthy):
         """Single-environment workflow — 6/6."""
         with (
-            patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj,
+            patch(
+                "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+            ) as mock_proj,
             patch("railguey.lib.doctor._gql", new_callable=AsyncMock) as mock_gql,
         ):
             mock_proj.return_value = {"projectId": "proj-1", "environmentId": "env-1"}
             mock_gql.side_effect = [
-                {"project": {
-                    "environments": {"edges": [{"node": {"id": "env-1", "name": "production"}}]},
-                    "services": {"edges": [{"node": {"id": "svc-1", "name": "web"}}]},
-                }},
+                {
+                    "project": {
+                        "environments": {
+                            "edges": [{"node": {"id": "env-1", "name": "production"}}]
+                        },
+                        "services": {
+                            "edges": [{"node": {"id": "svc-1", "name": "web"}}]
+                        },
+                    }
+                },
                 {"service": {"id": "svc-1", "name": "web", "repoTriggers": []}},
             ]
             result = await doctor(str(workspace_healthy))
         assert result["workspace"]["score"] == "6/6"
         assert result["workspace"]["healthy"] is True
 
-    @pytest.mark.xfail(reason="Pre-existing: doctor result structure changed to nested workspace/service/project")
+    @pytest.mark.xfail(
+        reason="Pre-existing: doctor result structure changed to nested workspace/service/project"
+    )
     @pytest.mark.asyncio
     async def test_perfect_score_multi_env(self, workspace_with_token):
         """Multi-environment workflow with correct token scope — 6/6."""
@@ -236,7 +268,9 @@ class TestDoctor:
         )
         proj_return, gql_calls = _mock_project_and_envs("production")
         with (
-            patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj,
+            patch(
+                "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+            ) as mock_proj,
             patch("railguey.lib.doctor._gql", new_callable=AsyncMock) as mock_gql,
         ):
             mock_proj.return_value = proj_return
@@ -247,7 +281,9 @@ class TestDoctor:
         assert checks["Token environment scope"]["status"] == "fail"
         assert "develop" in checks["Token environment scope"]["message"]
 
-    @pytest.mark.xfail(reason="Pre-existing: doctor result structure changed to nested workspace/service/project")
+    @pytest.mark.xfail(
+        reason="Pre-existing: doctor result structure changed to nested workspace/service/project"
+    )
     @pytest.mark.asyncio
     async def test_token_scope_mismatch_fails(self, workspace_with_token):
         """Token scoped to production, workflow targets both — should fail check 5."""
@@ -270,7 +306,9 @@ class TestDoctor:
         )
         proj_return, gql_calls = _mock_project_and_envs("production")
         with (
-            patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj,
+            patch(
+                "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+            ) as mock_proj,
             patch("railguey.lib.doctor._gql", new_callable=AsyncMock) as mock_gql,
         ):
             mock_proj.return_value = proj_return
@@ -302,7 +340,9 @@ class TestDoctor:
             "        env:\n"
             "          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}\n",
         )
-        with patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj:
+        with patch(
+            "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+        ) as mock_proj:
             mock_proj.return_value = {"error": "skip"}
             result = await doctor(str(workspace_with_token))
         checks = {f["check"]: f for f in result["workspace"]["findings"]}
@@ -310,7 +350,9 @@ class TestDoctor:
         assert "1 branch" in checks["CI/CD workflow"]["message"]
         assert "2 environment" in checks["CI/CD workflow"]["message"]
 
-    @pytest.mark.xfail(reason="Pre-existing: doctor result structure changed to nested workspace/service/project")
+    @pytest.mark.xfail(
+        reason="Pre-existing: doctor result structure changed to nested workspace/service/project"
+    )
     @pytest.mark.asyncio
     async def test_invalid_environment_name_fails(self, workspace_with_token):
         """Workflow references an environment that doesn't exist in Railway."""
@@ -333,7 +375,9 @@ class TestDoctor:
         )
         proj_return, gql_calls = _mock_project_and_envs("production")
         with (
-            patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj,
+            patch(
+                "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+            ) as mock_proj,
             patch("railguey.lib.doctor._gql", new_callable=AsyncMock) as mock_gql,
         ):
             mock_proj.return_value = proj_return
@@ -343,21 +387,37 @@ class TestDoctor:
         assert checks["Environment names"]["status"] == "fail"
         assert "staging" in checks["Environment names"]["message"]
 
-    @pytest.mark.xfail(reason="Pre-existing: doctor result structure changed to nested workspace/service/project")
+    @pytest.mark.xfail(
+        reason="Pre-existing: doctor result structure changed to nested workspace/service/project"
+    )
     @pytest.mark.asyncio
     async def test_linked_repo_warns(self, workspace_with_token):
         write_file(workspace_with_token / ".gitignore", ".env.local\n")
         with (
-            patch("railguey.lib.doctor._resolve_project", new_callable=AsyncMock) as mock_proj,
+            patch(
+                "railguey.lib.doctor._resolve_project", new_callable=AsyncMock
+            ) as mock_proj,
             patch("railguey.lib.doctor._gql", new_callable=AsyncMock) as mock_gql,
         ):
             mock_proj.return_value = {"projectId": "proj-1", "environmentId": "env-1"}
             mock_gql.side_effect = [
-                {"project": {
-                    "environments": {"edges": [{"node": {"id": "env-1", "name": "production"}}]},
-                    "services": {"edges": [{"node": {"id": "svc-1", "name": "web"}}]},
-                }},
-                {"service": {"id": "svc-1", "name": "web", "repoTriggers": [{"repository": "org/repo", "branch": "main"}]}},
+                {
+                    "project": {
+                        "environments": {
+                            "edges": [{"node": {"id": "env-1", "name": "production"}}]
+                        },
+                        "services": {
+                            "edges": [{"node": {"id": "svc-1", "name": "web"}}]
+                        },
+                    }
+                },
+                {
+                    "service": {
+                        "id": "svc-1",
+                        "name": "web",
+                        "repoTriggers": [{"repository": "org/repo", "branch": "main"}],
+                    }
+                },
             ]
             result = await doctor(str(workspace_with_token))
         checks = {f["check"]: f for f in result["workspace"]["findings"]}

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -4,21 +4,35 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from railguey.lib.graphql import _gql, _resolve_project, _resolve_service_id
-from tests.helpers import mock_httpx_response, mock_httpx_client, PROJECT_DATA, SERVICES_DATA
+from tests.helpers import (
+    mock_httpx_response,
+    mock_httpx_client,
+    PROJECT_DATA,
+    SERVICES_DATA,
+)
 
 
 class TestGql:
     @pytest.mark.asyncio
     async def test_successful_query(self):
-        resp = mock_httpx_response({
-            "data": {"projectToken": {"projectId": "proj-123", "environmentId": "env-456"}}
-        })
+        resp = mock_httpx_response(
+            {
+                "data": {
+                    "projectToken": {
+                        "projectId": "proj-123",
+                        "environmentId": "env-456",
+                    }
+                }
+            }
+        )
         client = mock_httpx_client(resp)
 
         with patch("railguey.lib.graphql.httpx.AsyncClient", return_value=client):
             result = await _gql("token", "query { projectToken { projectId } }")
 
-        assert result == {"projectToken": {"projectId": "proj-123", "environmentId": "env-456"}}
+        assert result == {
+            "projectToken": {"projectId": "proj-123", "environmentId": "env-456"}
+        }
 
     @pytest.mark.asyncio
     async def test_graphql_error(self):
@@ -87,7 +101,9 @@ class TestResolveServiceId:
         with patch("railguey.lib.graphql._gql", new_callable=AsyncMock) as mock:
             mock.return_value = {
                 "project": {
-                    "services": {"edges": [{"node": {"id": "svc-111", "name": "Cerebro"}}]}
+                    "services": {
+                        "edges": [{"node": {"id": "svc-111", "name": "Cerebro"}}]
+                    }
                 }
             }
             result = await _resolve_service_id("token", "proj-abc", "cerebro")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -211,7 +211,9 @@ class TestDeploymentsReal:
             }
             """
             svc_result = await _gql(token, query, {"id": project["projectId"]})
-            services = svc_result.get("project", {}).get("services", {}).get("edges", [])
+            services = (
+                svc_result.get("project", {}).get("services", {}).get("edges", [])
+            )
             if services:
                 svc_name = services[0]["node"]["name"]
                 result = await deployments(ws, service=svc_name, limit=3)
@@ -244,7 +246,9 @@ class TestDeploymentsReal:
             }
             """
             svc_result = await _gql(token, query, {"id": project["projectId"]})
-            services = svc_result.get("project", {}).get("services", {}).get("edges", [])
+            services = (
+                svc_result.get("project", {}).get("services", {}).get("edges", [])
+            )
             if not services:
                 results.append(f"  SKIP {name}: no services")
                 continue
@@ -296,7 +300,9 @@ class TestServiceInfoReal:
         print(f"  Health: {info.get('healthcheckPath', 'none')}")
         latest = info.get("latestDeployment", {})
         if latest:
-            print(f"  Latest: {latest.get('status', '?')} @ {latest.get('createdAt', '?')[:19]}")
+            print(
+                f"  Latest: {latest.get('status', '?')} @ {latest.get('createdAt', '?')[:19]}"
+            )
 
 
 @skip_no_workspaces
@@ -310,7 +316,9 @@ class TestDoctorReal:
         assert "findings" in result
         assert "score" in result
         name = Path(workspace).name
-        print(f"\n  {name}: {result['score']} {'HEALTHY' if result['healthy'] else 'ISSUES'}")
+        print(
+            f"\n  {name}: {result['score']} {'HEALTHY' if result['healthy'] else 'ISSUES'}"
+        )
         for f in result["findings"]:
             status = f["status"].upper()
             print(f"    [{status:4}] {f['check']}: {f['message']}")

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -13,8 +13,13 @@ from unittest.mock import AsyncMock, patch
 
 
 from railguey.lib.orchestrate import (
-    registry, preflight, verify, deploy_plan,
-    _load_registry, _find_service, _expand_home,
+    registry,
+    preflight,
+    verify,
+    deploy_plan,
+    _load_registry,
+    _find_service,
+    _expand_home,
 )
 
 
@@ -37,20 +42,38 @@ def _patch_project(project: dict | None = None):
     return patch(
         "railguey.lib.orchestrate._resolve_project",
         new_callable=AsyncMock,
-        return_value=project if project is not None else {"projectId": "proj-1", "environmentId": "env-1"},
+        return_value=project
+        if project is not None
+        else {"projectId": "proj-1", "environmentId": "env-1"},
     )
 
 
 def _patch_service_id(side_effect=None, return_value: str | None = "svc-1"):
     if side_effect is not None:
-        return patch("railguey.lib.orchestrate._resolve_service_id", new_callable=AsyncMock, side_effect=side_effect)
-    return patch("railguey.lib.orchestrate._resolve_service_id", new_callable=AsyncMock, return_value=return_value)
+        return patch(
+            "railguey.lib.orchestrate._resolve_service_id",
+            new_callable=AsyncMock,
+            side_effect=side_effect,
+        )
+    return patch(
+        "railguey.lib.orchestrate._resolve_service_id",
+        new_callable=AsyncMock,
+        return_value=return_value,
+    )
 
 
 def _patch_gql(*responses):
     if len(responses) == 1:
-        return patch("railguey.lib.orchestrate._gql", new_callable=AsyncMock, return_value=responses[0])
-    return patch("railguey.lib.orchestrate._gql", new_callable=AsyncMock, side_effect=list(responses))
+        return patch(
+            "railguey.lib.orchestrate._gql",
+            new_callable=AsyncMock,
+            return_value=responses[0],
+        )
+    return patch(
+        "railguey.lib.orchestrate._gql",
+        new_callable=AsyncMock,
+        side_effect=list(responses),
+    )
 
 
 def _ok_proc(stdout: str = ""):
@@ -152,16 +175,25 @@ class TestPreflight:
             "defaults": {"preflight": {"require_clean_worktree": True}},
             "services": [
                 {
-                    "name": "db-migrations", "type": "migrations", "repo": "db-migrations",
-                    "workspace": ws_migrations, "deploy": {"branch": "main"},
+                    "name": "db-migrations",
+                    "type": "migrations",
+                    "repo": "db-migrations",
+                    "workspace": ws_migrations,
+                    "deploy": {"branch": "main"},
                 },
                 {
-                    "name": "dep-api", "type": "railway_service", "repo": "dep-api",
-                    "workspace": ws_dep_api, "deploy": {"branch": "main"},
+                    "name": "dep-api",
+                    "type": "railway_service",
+                    "repo": "dep-api",
+                    "workspace": ws_dep_api,
+                    "deploy": {"branch": "main"},
                 },
                 {
-                    "name": "api", "type": "railway_service", "repo": "api",
-                    "workspace": ws_service, "deploy": {"branch": "main"},
+                    "name": "api",
+                    "type": "railway_service",
+                    "repo": "api",
+                    "workspace": ws_service,
+                    "deploy": {"branch": "main"},
                     "depends_on": [
                         {"target": "db-migrations", "gate": "required_before_deploy"},
                         {"target": "dep-api", "gate": "required_before_deploy"},
@@ -174,7 +206,9 @@ class TestPreflight:
         ws = str(workspace_with_token)
         reg = self._base_registry(ws, str(tmp_path / "db"), str(tmp_path / "dep"))
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -183,14 +217,18 @@ class TestPreflight:
                 return _ok_proc("20260101_init | 20260101_init | 2026-01-01\n")
             raise AssertionError(f"Unexpected subprocess: {cmd}")
 
-        gql_concurrency = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}}
+        gql_concurrency = {
+            "deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}
+        }
         gql_dep_api = {"deployments": {"edges": [{"node": {"status": "SUCCESS"}}]}}
 
         with (
             _patch_registry(reg),
             _patch_token(),
             _patch_project(),
-            _patch_service_id(side_effect=lambda token, project_id, name: f"sid-{name}"),
+            _patch_service_id(
+                side_effect=lambda token, project_id, name: f"sid-{name}"
+            ),
             _patch_gql(gql_concurrency, gql_dep_api),
             patch("subprocess.run", side_effect=run_side_effect),
         ):
@@ -215,18 +253,28 @@ class TestPreflight:
     async def test_wrong_branch_blocks(self, workspace_with_token):
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("develop\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
                 return _ok_proc("")
             raise AssertionError(f"Unexpected subprocess: {cmd}")
 
-        gql = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}}
+        gql = {
+            "deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}
+        }
 
         with (
             _patch_registry(reg),
@@ -244,18 +292,28 @@ class TestPreflight:
     async def test_dirty_worktree_blocks(self, workspace_with_token):
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
                 return _ok_proc(" M app.py\n?? new.txt\n")
             raise AssertionError(f"Unexpected subprocess: {cmd}")
 
-        gql = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}}
+        gql = {
+            "deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}
+        }
 
         with (
             _patch_registry(reg),
@@ -273,18 +331,28 @@ class TestPreflight:
     async def test_concurrent_deploy_blocks(self, workspace_with_token):
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
                 return _ok_proc("")
             raise AssertionError(f"Unexpected subprocess: {cmd}")
 
-        gql = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "BUILDING"}}]}}
+        gql = {
+            "deployments": {"edges": [{"node": {"id": "dep-1", "status": "BUILDING"}}]}
+        }
 
         with (
             _patch_registry(reg),
@@ -299,11 +367,15 @@ class TestPreflight:
         assert result["go"] is False
         assert any(b["check"] == "concurrency" for b in result["blocking"])
 
-    async def test_migrations_dependency_unsynced_blocks(self, workspace_with_token, tmp_path):
+    async def test_migrations_dependency_unsynced_blocks(
+        self, workspace_with_token, tmp_path
+    ):
         ws = str(workspace_with_token)
         reg = self._base_registry(ws, str(tmp_path / "db"), str(tmp_path / "dep"))
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -313,14 +385,18 @@ class TestPreflight:
                 return _ok_proc("20260101_init |  | 2026-01-01\n")
             raise AssertionError(f"Unexpected subprocess: {cmd}")
 
-        gql_concurrency = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}}
+        gql_concurrency = {
+            "deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}
+        }
         gql_dep_api = {"deployments": {"edges": [{"node": {"status": "SUCCESS"}}]}}
 
         with (
             _patch_registry(reg),
             _patch_token(),
             _patch_project(),
-            _patch_service_id(side_effect=lambda token, project_id, name: f"sid-{name}"),
+            _patch_service_id(
+                side_effect=lambda token, project_id, name: f"sid-{name}"
+            ),
             _patch_gql(gql_concurrency, gql_dep_api),
             patch("subprocess.run", side_effect=run_side_effect),
         ):
@@ -344,7 +420,9 @@ class TestVerify:
     async def test_non_railway_service_skips_and_passes(self, workspace):
         reg = {
             "defaults": {"verify": {"timeout_seconds": 1, "poll_interval_seconds": 0}},
-            "services": [{"name": "db", "type": "migrations", "workspace": str(workspace)}],
+            "services": [
+                {"name": "db", "type": "migrations", "workspace": str(workspace)}
+            ],
         }
         with _patch_registry(reg):
             result = await verify("db", workspace=str(workspace))
@@ -354,10 +432,28 @@ class TestVerify:
 
     async def test_deploy_failed_early_exit(self, workspace_with_token):
         reg = {
-            "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0, "success_streak": 2}},
-            "services": [{"name": "api", "type": "railway_service", "workspace": str(workspace_with_token)}],
+            "defaults": {
+                "verify": {
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "success_streak": 2,
+                }
+            },
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                }
+            ],
         }
-        dep_failed = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "FAILED", "createdAt": "t"}}]}}
+        dep_failed = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "FAILED", "createdAt": "t"}}
+                ]
+            }
+        }
 
         with (
             _patch_registry(reg),
@@ -370,16 +466,31 @@ class TestVerify:
             result = await verify("api", workspace=str(workspace_with_token))
 
         assert result["pass"] is False
-        assert any(c["check"] == "deploy_poll" and c["status"] == "fail" for c in result["checks"])
+        assert any(
+            c["check"] == "deploy_poll" and c["status"] == "fail"
+            for c in result["checks"]
+        )
         # Should not proceed to log scan
         assert not any(c["check"] == "log_scan" for c in result["checks"])
 
     async def test_deploy_timeout_fails(self, workspace_with_token):
         reg = {
             "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0}},
-            "services": [{"name": "api", "type": "railway_service", "workspace": str(workspace_with_token)}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                }
+            ],
         }
-        dep_building = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "DEPLOYING", "createdAt": "t"}}]}}
+        dep_building = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "DEPLOYING", "createdAt": "t"}}
+                ]
+            }
+        }
 
         with (
             _patch_registry(reg),
@@ -401,22 +512,42 @@ class TestVerify:
         reg = {
             "defaults": {
                 "verify": {
-                    "timeout_seconds": 5, "poll_interval_seconds": 0,
-                    "log_tail_lines": 10, "fail_fast_patterns": ["Traceback"], "success_streak": 2,
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "log_tail_lines": 10,
+                    "fail_fast_patterns": ["Traceback"],
+                    "success_streak": 2,
                 }
             },
-            "services": [{
-                "name": "api", "type": "railway_service", "workspace": str(workspace_with_token),
-                "health": {"http": {"path": "/health", "expect_status": 200}, "log_patterns": {"fail_fast": []}},
-                "verify": {"success_streak": 2},
-            }],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "health": {
+                        "http": {"path": "/health", "expect_status": 200},
+                        "log_patterns": {"fail_fast": []},
+                    },
+                    "verify": {"success_streak": 2},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
         logs_with_error = {
             "deploymentLogs": [
                 {"message": "INFO booting", "timestamp": "t", "severity": "info"},
-                {"message": "Traceback (most recent call last): boom", "timestamp": "t", "severity": "error"},
+                {
+                    "message": "Traceback (most recent call last): boom",
+                    "timestamp": "t",
+                    "severity": "error",
+                },
             ]
         }
 
@@ -431,7 +562,9 @@ class TestVerify:
             result = await verify("api", workspace=str(workspace_with_token))
 
         assert result["pass"] is False
-        assert any(c["check"] == "log_scan" and c["status"] == "fail" for c in result["checks"])
+        assert any(
+            c["check"] == "log_scan" and c["status"] == "fail" for c in result["checks"]
+        )
         # Should not proceed to health check
         assert not any(c["check"] == "health_http" for c in result["checks"])
 
@@ -439,25 +572,46 @@ class TestVerify:
         reg = {
             "defaults": {
                 "verify": {
-                    "timeout_seconds": 5, "poll_interval_seconds": 0,
-                    "log_tail_lines": 10, "fail_fast_patterns": [], "success_streak": 2,
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "log_tail_lines": 10,
+                    "fail_fast_patterns": [],
+                    "success_streak": 2,
                 }
             },
-            "services": [{
-                "name": "api", "type": "railway_service", "workspace": str(workspace_with_token),
-                "health": {"http": {"path": "/health", "expect_status": 200}},
-                "verify": {"success_streak": 2},
-            }],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "health": {"http": {"path": "/health", "expect_status": 200}},
+                    "verify": {"success_streak": 2},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
         svc_domains = {
             "service": {
                 "serviceInstances": {
-                    "edges": [{"node": {"domains": {
-                        "customDomains": [],
-                        "serviceDomains": [{"domain": "api.up.railway.app"}],
-                    }}}]
+                    "edges": [
+                        {
+                            "node": {
+                                "domains": {
+                                    "customDomains": [],
+                                    "serviceDomains": [
+                                        {"domain": "api.up.railway.app"}
+                                    ],
+                                }
+                            }
+                        }
+                    ]
                 }
             }
         }
@@ -468,32 +622,62 @@ class TestVerify:
             _patch_project(),
             _patch_service_id(return_value="sid-api"),
             _patch_gql(dep_success, svc_domains),
-            patch("railguey.lib.orchestrate.httpx.AsyncClient", new=_fake_client_factory([200, 200])),
+            patch(
+                "railguey.lib.orchestrate.httpx.AsyncClient",
+                new=_fake_client_factory([200, 200]),
+            ),
             patch("railguey.lib.orchestrate.asyncio.sleep", new_callable=AsyncMock),
         ):
             result = await verify("api", workspace=str(workspace_with_token))
 
         assert result["pass"] is True
-        assert any(c["check"] == "health_http" and c["status"] == "pass" for c in result["checks"])
+        assert any(
+            c["check"] == "health_http" and c["status"] == "pass"
+            for c in result["checks"]
+        )
 
     async def test_health_streak_fails(self, workspace_with_token):
         reg = {
-            "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0, "fail_fast_patterns": []}},
-            "services": [{
-                "name": "api", "type": "railway_service", "workspace": str(workspace_with_token),
-                "health": {"http": {"path": "/health", "expect_status": 200}},
-                "verify": {"success_streak": 2},
-            }],
+            "defaults": {
+                "verify": {
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "fail_fast_patterns": [],
+                }
+            },
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "health": {"http": {"path": "/health", "expect_status": 200}},
+                    "verify": {"success_streak": 2},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
         svc_domains = {
             "service": {
                 "serviceInstances": {
-                    "edges": [{"node": {"domains": {
-                        "customDomains": [],
-                        "serviceDomains": [{"domain": "api.up.railway.app"}],
-                    }}}]
+                    "edges": [
+                        {
+                            "node": {
+                                "domains": {
+                                    "customDomains": [],
+                                    "serviceDomains": [
+                                        {"domain": "api.up.railway.app"}
+                                    ],
+                                }
+                            }
+                        }
+                    ]
                 }
             }
         }
@@ -504,28 +688,60 @@ class TestVerify:
             _patch_project(),
             _patch_service_id(return_value="sid-api"),
             _patch_gql(dep_success, svc_domains),
-            patch("railguey.lib.orchestrate.httpx.AsyncClient", new=_fake_client_factory([500, 500, 500, 500])),
+            patch(
+                "railguey.lib.orchestrate.httpx.AsyncClient",
+                new=_fake_client_factory([500, 500, 500, 500]),
+            ),
             patch("railguey.lib.orchestrate.asyncio.sleep", new_callable=AsyncMock),
         ):
             result = await verify("api", workspace=str(workspace_with_token))
 
         assert result["pass"] is False
-        assert any(c["check"] == "health_http" and c["status"] == "fail" for c in result["checks"])
+        assert any(
+            c["check"] == "health_http" and c["status"] == "fail"
+            for c in result["checks"]
+        )
 
     async def test_no_domain_skips_health_but_passes(self, workspace_with_token):
         reg = {
-            "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0, "fail_fast_patterns": []}},
-            "services": [{
-                "name": "api", "type": "railway_service", "workspace": str(workspace_with_token),
-                "health": {"http": {"path": "/health", "expect_status": 200}},
-                "verify": {"success_streak": 2},
-            }],
+            "defaults": {
+                "verify": {
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "fail_fast_patterns": [],
+                }
+            },
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "health": {"http": {"path": "/health", "expect_status": 200}},
+                    "verify": {"success_streak": 2},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
-        svc_no_domains = {"service": {"serviceInstances": {"edges": [
-            {"node": {"domains": {"customDomains": [], "serviceDomains": []}}}
-        ]}}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
+        svc_no_domains = {
+            "service": {
+                "serviceInstances": {
+                    "edges": [
+                        {
+                            "node": {
+                                "domains": {"customDomains": [], "serviceDomains": []}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
 
         with (
             _patch_registry(reg),
@@ -538,7 +754,10 @@ class TestVerify:
             result = await verify("api", workspace=str(workspace_with_token))
 
         assert result["pass"] is True
-        assert any(c["check"] == "health_http" and c["status"] == "skip" for c in result["checks"])
+        assert any(
+            c["check"] == "health_http" and c["status"] == "skip"
+            for c in result["checks"]
+        )
 
     async def test_unknown_service_fails(self):
         reg = {"services": [{"name": "api"}]}
@@ -562,16 +781,27 @@ class TestDeployPlan:
     def _plan_registry(self):
         return {
             "services": [
-                {"name": "db", "type": "migrations", "repo": "db-repo", "deploy": {"branch": "main"}},
                 {
-                    "name": "api", "type": "railway_service", "repo": "api-repo",
+                    "name": "db",
+                    "type": "migrations",
+                    "repo": "db-repo",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "repo": "api-repo",
                     "deploy": {"branch": "main"},
                     "depends_on": [{"target": "db", "gate": "required_before_deploy"}],
                 },
                 {
-                    "name": "web", "type": "railway_service", "repo": "web-repo",
+                    "name": "web",
+                    "type": "railway_service",
+                    "repo": "web-repo",
                     "deploy": {"branch": "main"},
-                    "depends_on": [{"target": "api", "gate": "recommended_before_verify"}],
+                    "depends_on": [
+                        {"target": "api", "gate": "recommended_before_verify"}
+                    ],
                 },
             ]
         }
@@ -631,17 +861,32 @@ class TestDeployPlan:
         """Stage with >1 service gets parallel=True."""
         reg = {
             "services": [
-                {"name": "db", "type": "migrations", "repo": "db-repo", "deploy": {"branch": "main"}},
-                {"name": "api-a", "type": "railway_service", "repo": "api-a-repo",
-                 "deploy": {"branch": "main"}},
-                {"name": "api-b", "type": "railway_service", "repo": "api-b-repo",
-                 "deploy": {"branch": "main"}},
+                {
+                    "name": "db",
+                    "type": "migrations",
+                    "repo": "db-repo",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "api-a",
+                    "type": "railway_service",
+                    "repo": "api-a-repo",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "api-b",
+                    "type": "railway_service",
+                    "repo": "api-b-repo",
+                    "deploy": {"branch": "main"},
+                },
             ]
         }
         with _patch_registry(reg):
             result = await deploy_plan(["api-a-repo", "api-b-repo"])
         # Both are leaf services (no one depends on them) → same stage
-        leaf_stage = next(s for s in result["stages"] if s["label"] == "Frontends and workers")
+        leaf_stage = next(
+            s for s in result["stages"] if s["label"] == "Frontends and workers"
+        )
         assert leaf_stage["parallel"] is True
 
     async def test_registry_error_passthrough(self):
@@ -653,13 +898,26 @@ class TestDeployPlan:
         """A→B→C: changing A should auto-include B and C."""
         reg = {
             "services": [
-                {"name": "c", "type": "migrations", "repo": "c-repo", "deploy": {"branch": "main"}},
-                {"name": "b", "type": "railway_service", "repo": "b-repo",
-                 "deploy": {"branch": "main"},
-                 "depends_on": [{"target": "c", "gate": "required_before_deploy"}]},
-                {"name": "a", "type": "railway_service", "repo": "a-repo",
-                 "deploy": {"branch": "main"},
-                 "depends_on": [{"target": "b", "gate": "required_before_deploy"}]},
+                {
+                    "name": "c",
+                    "type": "migrations",
+                    "repo": "c-repo",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "b",
+                    "type": "railway_service",
+                    "repo": "b-repo",
+                    "deploy": {"branch": "main"},
+                    "depends_on": [{"target": "c", "gate": "required_before_deploy"}],
+                },
+                {
+                    "name": "a",
+                    "type": "railway_service",
+                    "repo": "a-repo",
+                    "deploy": {"branch": "main"},
+                    "depends_on": [{"target": "b", "gate": "required_before_deploy"}],
+                },
             ]
         }
         with _patch_registry(reg):
@@ -672,11 +930,19 @@ class TestDeployPlan:
         """When no migrations in plan, stage numbers still start at correct values."""
         reg = {
             "services": [
-                {"name": "api", "type": "railway_service", "repo": "api-repo",
-                 "deploy": {"branch": "main"}},
-                {"name": "web", "type": "railway_service", "repo": "web-repo",
-                 "deploy": {"branch": "main"},
-                 "depends_on": [{"target": "api", "gate": "required_before_deploy"}]},
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "repo": "api-repo",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "web",
+                    "type": "railway_service",
+                    "repo": "web-repo",
+                    "deploy": {"branch": "main"},
+                    "depends_on": [{"target": "api", "gate": "required_before_deploy"}],
+                },
             ]
         }
         with _patch_registry(reg):
@@ -693,13 +959,26 @@ class TestDeployPlan:
         """A service that others depend on lands in stage 2 (API layer)."""
         reg = {
             "services": [
-                {"name": "db", "type": "migrations", "repo": "db-repo", "deploy": {"branch": "main"}},
-                {"name": "api", "type": "railway_service", "repo": "api-repo",
-                 "deploy": {"branch": "main"},
-                 "depends_on": [{"target": "db", "gate": "required_before_deploy"}]},
-                {"name": "web", "type": "railway_service", "repo": "web-repo",
-                 "deploy": {"branch": "main"},
-                 "depends_on": [{"target": "api", "gate": "required_before_deploy"}]},
+                {
+                    "name": "db",
+                    "type": "migrations",
+                    "repo": "db-repo",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "repo": "api-repo",
+                    "deploy": {"branch": "main"},
+                    "depends_on": [{"target": "db", "gate": "required_before_deploy"}],
+                },
+                {
+                    "name": "web",
+                    "type": "railway_service",
+                    "repo": "web-repo",
+                    "deploy": {"branch": "main"},
+                    "depends_on": [{"target": "api", "gate": "required_before_deploy"}],
+                },
             ]
         }
         with _patch_registry(reg):
@@ -712,8 +991,12 @@ class TestDeployPlan:
         """Stage with exactly 1 service gets parallel=False."""
         reg = {
             "services": [
-                {"name": "solo", "type": "railway_service", "repo": "solo-repo",
-                 "deploy": {"branch": "main"}},
+                {
+                    "name": "solo",
+                    "type": "railway_service",
+                    "repo": "solo-repo",
+                    "deploy": {"branch": "main"},
+                },
             ]
         }
         with _patch_registry(reg):
@@ -767,7 +1050,9 @@ class TestFindService:
 class TestLoadRegistry:
     def test_returns_error_when_no_file_exists(self, tmp_path):
         """When neither registry path exists, returns error dict."""
-        with patch("railguey.lib.orchestrate._REGISTRY_PATHS", [tmp_path / "nope.yaml"]):
+        with patch(
+            "railguey.lib.orchestrate._REGISTRY_PATHS", [tmp_path / "nope.yaml"]
+        ):
             result = _load_registry()
         assert "error" in result
         assert "not found" in result["error"].lower()
@@ -790,8 +1075,14 @@ class TestPreflightEdgeCases:
         """When git branch fails, check is skipped (not blocking)."""
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": False}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
         with (
@@ -799,7 +1090,13 @@ class TestPreflightEdgeCases:
             _patch_token(),
             _patch_project(),
             _patch_service_id(return_value="sid-api"),
-            _patch_gql({"deployments": {"edges": [{"node": {"id": "d1", "status": "SUCCESS"}}]}}),
+            _patch_gql(
+                {
+                    "deployments": {
+                        "edges": [{"node": {"id": "d1", "status": "SUCCESS"}}]
+                    }
+                }
+            ),
             patch("subprocess.run", side_effect=OSError("git not found")),
         ):
             result = await preflight("api", workspace=str(workspace_with_token))
@@ -813,8 +1110,9 @@ class TestPreflightEdgeCases:
         """Service with no workspace path skips local checks."""
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "deploy": {"branch": "main"}}],  # no workspace key
+            "services": [
+                {"name": "api", "type": "railway_service", "deploy": {"branch": "main"}}
+            ],  # no workspace key
         }
         with _patch_registry(reg):
             result = await preflight("api")
@@ -823,15 +1121,25 @@ class TestPreflightEdgeCases:
         assert result["passed"] == []
         assert result["blocking"] == []
 
-    async def test_non_railway_service_skips_concurrency_check(self, workspace_with_token):
+    async def test_non_railway_service_skips_concurrency_check(
+        self, workspace_with_token
+    ):
         """Migrations type doesn't get concurrency check."""
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "db", "type": "migrations",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "db",
+                    "type": "migrations",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -852,11 +1160,19 @@ class TestPreflightEdgeCases:
         """When Railway API returns error, concurrency check is skipped."""
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -880,14 +1196,22 @@ class TestPreflightEdgeCases:
         """Dependency pointing to unknown service blocks deploy."""
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{
-                "name": "api", "type": "railway_service",
-                "workspace": str(workspace_with_token), "deploy": {"branch": "main"},
-                "depends_on": [{"target": "phantom-db", "gate": "required_before_deploy"}],
-            }],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                    "depends_on": [
+                        {"target": "phantom-db", "gate": "required_before_deploy"}
+                    ],
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -914,17 +1238,27 @@ class TestPreflightEdgeCases:
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
             "services": [
-                {"name": "ai-svc", "type": "railway_service", "workspace": "/tmp/ai",
-                 "deploy": {"branch": "main"}},
                 {
-                    "name": "web", "type": "railway_service",
-                    "workspace": str(workspace_with_token), "deploy": {"branch": "main"},
-                    "depends_on": [{"target": "ai-svc", "gate": "recommended_before_verify"}],
+                    "name": "ai-svc",
+                    "type": "railway_service",
+                    "workspace": "/tmp/ai",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "web",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                    "depends_on": [
+                        {"target": "ai-svc", "gate": "recommended_before_verify"}
+                    ],
                 },
             ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -948,62 +1282,92 @@ class TestPreflightEdgeCases:
         all_check_names = [c["check"] for c in result["passed"] + result["blocking"]]
         assert "dependency:ai-svc" not in all_check_names
 
-    async def test_railway_dependency_failed_blocks(self, workspace_with_token, tmp_path):
+    async def test_railway_dependency_failed_blocks(
+        self, workspace_with_token, tmp_path
+    ):
         """Railway service dependency with FAILED status blocks deploy."""
         ws = str(workspace_with_token)
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
             "services": [
-                {"name": "dep-api", "type": "railway_service", "repo": "dep-api",
-                 "workspace": str(tmp_path / "dep"), "deploy": {"branch": "main"}},
                 {
-                    "name": "api", "type": "railway_service", "repo": "api",
-                    "workspace": ws, "deploy": {"branch": "main"},
-                    "depends_on": [{"target": "dep-api", "gate": "required_before_deploy"}],
+                    "name": "dep-api",
+                    "type": "railway_service",
+                    "repo": "dep-api",
+                    "workspace": str(tmp_path / "dep"),
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "repo": "api",
+                    "workspace": ws,
+                    "deploy": {"branch": "main"},
+                    "depends_on": [
+                        {"target": "dep-api", "gate": "required_before_deploy"}
+                    ],
                 },
             ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
                 return _ok_proc("")
             raise AssertionError(f"Unexpected subprocess: {cmd}")
 
-        gql_concurrency = {"deployments": {"edges": [{"node": {"id": "d1", "status": "SUCCESS"}}]}}
+        gql_concurrency = {
+            "deployments": {"edges": [{"node": {"id": "d1", "status": "SUCCESS"}}]}
+        }
         gql_dep_failed = {"deployments": {"edges": [{"node": {"status": "FAILED"}}]}}
 
         with (
             _patch_registry(reg),
             _patch_token(),
             _patch_project(),
-            _patch_service_id(side_effect=lambda token, project_id, name: f"sid-{name}"),
+            _patch_service_id(
+                side_effect=lambda token, project_id, name: f"sid-{name}"
+            ),
             _patch_gql(gql_concurrency, gql_dep_failed),
             patch("subprocess.run", side_effect=run_side_effect),
         ):
             result = await preflight("api", workspace=ws)
 
         assert result["go"] is False
-        dep_block = next(b for b in result["blocking"] if b["check"] == "dependency:dep-api")
+        dep_block = next(
+            b for b in result["blocking"] if b["check"] == "dependency:dep-api"
+        )
         assert "FAILED" in dep_block["detail"]
 
     async def test_multiple_blocking_issues_counted(self, workspace_with_token):
         """Multiple failures produce correct summary count."""
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("develop\n")  # wrong branch
             if cmd[:3] == ["git", "status", "--porcelain"]:
                 return _ok_proc(" M dirty.py\n")  # dirty
             raise AssertionError(f"Unexpected subprocess: {cmd}")
 
-        gql = {"deployments": {"edges": [{"node": {"id": "d1", "status": "BUILDING"}}]}}  # concurrent
+        gql = {
+            "deployments": {"edges": [{"node": {"id": "d1", "status": "BUILDING"}}]}
+        }  # concurrent
 
         with (
             _patch_registry(reg),
@@ -1040,7 +1404,13 @@ class TestVerifyEdgeCases:
     async def test_resolve_project_error_fails(self, workspace_with_token):
         reg = {
             "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0}},
-            "services": [{"name": "api", "type": "railway_service", "workspace": str(workspace_with_token)}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                }
+            ],
         }
         with (
             _patch_registry(reg),
@@ -1049,12 +1419,21 @@ class TestVerifyEdgeCases:
         ):
             result = await verify("api", workspace=str(workspace_with_token))
         assert result["pass"] is False
-        assert any(c["check"] == "deploy_poll" and c["status"] == "fail" for c in result["checks"])
+        assert any(
+            c["check"] == "deploy_poll" and c["status"] == "fail"
+            for c in result["checks"]
+        )
 
     async def test_resolve_service_id_none_fails(self, workspace_with_token):
         reg = {
             "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0}},
-            "services": [{"name": "api", "type": "railway_service", "workspace": str(workspace_with_token)}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                }
+            ],
         }
         with (
             _patch_registry(reg),
@@ -1070,9 +1449,21 @@ class TestVerifyEdgeCases:
         """CRASHED is a terminal non-SUCCESS status."""
         reg = {
             "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0}},
-            "services": [{"name": "api", "type": "railway_service", "workspace": str(workspace_with_token)}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                }
+            ],
         }
-        dep_crashed = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "CRASHED", "createdAt": "t"}}]}}
+        dep_crashed = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "CRASHED", "createdAt": "t"}}
+                ]
+            }
+        }
 
         with (
             _patch_registry(reg),
@@ -1093,25 +1484,66 @@ class TestVerifyEdgeCases:
         reg = {
             "defaults": {
                 "verify": {
-                    "timeout_seconds": 5, "poll_interval_seconds": 0,
-                    "log_tail_lines": 10, "fail_fast_patterns": ["FATAL"], "success_streak": 2,
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "log_tail_lines": 10,
+                    "fail_fast_patterns": ["FATAL"],
+                    "success_streak": 2,
                 }
             },
-            "services": [{
-                "name": "api", "type": "railway_service", "workspace": str(workspace_with_token),
-                "health": {"http": {"path": "/health", "expect_status": 200}, "log_patterns": {"fail_fast": []}},
-                "verify": {"success_streak": 2},
-            }],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "health": {
+                        "http": {"path": "/health", "expect_status": 200},
+                        "log_patterns": {"fail_fast": []},
+                    },
+                    "verify": {"success_streak": 2},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
-        clean_logs = {"deploymentLogs": [
-            {"message": "INFO server started", "timestamp": "t", "severity": "info"},
-            {"message": "INFO listening on :3000", "timestamp": "t", "severity": "info"},
-        ]}
-        svc_domains = {"service": {"serviceInstances": {"edges": [
-            {"node": {"domains": {"customDomains": [], "serviceDomains": [{"domain": "api.up.railway.app"}]}}}
-        ]}}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
+        clean_logs = {
+            "deploymentLogs": [
+                {
+                    "message": "INFO server started",
+                    "timestamp": "t",
+                    "severity": "info",
+                },
+                {
+                    "message": "INFO listening on :3000",
+                    "timestamp": "t",
+                    "severity": "info",
+                },
+            ]
+        }
+        svc_domains = {
+            "service": {
+                "serviceInstances": {
+                    "edges": [
+                        {
+                            "node": {
+                                "domains": {
+                                    "customDomains": [],
+                                    "serviceDomains": [
+                                        {"domain": "api.up.railway.app"}
+                                    ],
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
 
         with (
             _patch_registry(reg),
@@ -1119,7 +1551,10 @@ class TestVerifyEdgeCases:
             _patch_project(),
             _patch_service_id(return_value="sid-api"),
             _patch_gql(dep_success, clean_logs, svc_domains),
-            patch("railguey.lib.orchestrate.httpx.AsyncClient", new=_fake_client_factory([200, 200])),
+            patch(
+                "railguey.lib.orchestrate.httpx.AsyncClient",
+                new=_fake_client_factory([200, 200]),
+            ),
             patch("railguey.lib.orchestrate.asyncio.sleep", new_callable=AsyncMock),
         ):
             result = await verify("api", workspace=str(workspace_with_token))
@@ -1134,15 +1569,31 @@ class TestVerifyEdgeCases:
     async def test_no_health_http_config_skips_health_check(self, workspace_with_token):
         """Service with no health.http config skips health check entirely."""
         reg = {
-            "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0, "fail_fast_patterns": []}},
-            "services": [{
-                "name": "worker", "type": "railway_service", "workspace": str(workspace_with_token),
-                # No health.http — just log patterns
-                "health": {"log_patterns": {"fail_fast": []}},
-            }],
+            "defaults": {
+                "verify": {
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "fail_fast_patterns": [],
+                }
+            },
+            "services": [
+                {
+                    "name": "worker",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    # No health.http — just log patterns
+                    "health": {"log_patterns": {"fail_fast": []}},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
 
         with (
             _patch_registry(reg),
@@ -1158,26 +1609,46 @@ class TestVerifyEdgeCases:
         check_names = [c["check"] for c in result["checks"]]
         assert "health_http" not in check_names
 
-    async def test_fail_patterns_merged_from_service_and_defaults(self, workspace_with_token):
+    async def test_fail_patterns_merged_from_service_and_defaults(
+        self, workspace_with_token
+    ):
         """Fail-fast patterns combine service-level + default-level."""
         reg = {
             "defaults": {
                 "verify": {
-                    "timeout_seconds": 5, "poll_interval_seconds": 0,
-                    "log_tail_lines": 10, "fail_fast_patterns": ["FATAL"],
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "log_tail_lines": 10,
+                    "fail_fast_patterns": ["FATAL"],
                 }
             },
-            "services": [{
-                "name": "api", "type": "railway_service", "workspace": str(workspace_with_token),
-                "health": {"log_patterns": {"fail_fast": ["SQLSTATE"]}},
-            }],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "health": {"log_patterns": {"fail_fast": ["SQLSTATE"]}},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
         # Log contains a service-level pattern (SQLSTATE), not a default one
-        logs = {"deploymentLogs": [
-            {"message": "ERROR: SQLSTATE[42P01] relation does not exist", "timestamp": "t", "severity": "error"},
-        ]}
+        logs = {
+            "deploymentLogs": [
+                {
+                    "message": "ERROR: SQLSTATE[42P01] relation does not exist",
+                    "timestamp": "t",
+                    "severity": "error",
+                },
+            ]
+        }
 
         with (
             _patch_registry(reg),
@@ -1194,27 +1665,55 @@ class TestVerifyEdgeCases:
         assert log_check["status"] == "fail"
         assert any(m["pattern"] == "SQLSTATE" for m in log_check["matches"])
 
-    async def test_custom_domain_preferred_over_service_domain(self, workspace_with_token):
+    async def test_custom_domain_preferred_over_service_domain(
+        self, workspace_with_token
+    ):
         """When both custom and service domains exist, URL uses first available."""
         reg = {
             "defaults": {
                 "verify": {
-                    "timeout_seconds": 5, "poll_interval_seconds": 0,
-                    "fail_fast_patterns": [], "success_streak": 2,
+                    "timeout_seconds": 5,
+                    "poll_interval_seconds": 0,
+                    "fail_fast_patterns": [],
+                    "success_streak": 2,
                 }
             },
-            "services": [{
-                "name": "api", "type": "railway_service", "workspace": str(workspace_with_token),
-                "health": {"http": {"path": "/health", "expect_status": 200}},
-                "verify": {"success_streak": 2},
-            }],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "health": {"http": {"path": "/health", "expect_status": 200}},
+                    "verify": {"success_streak": 2},
+                }
+            ],
         }
 
-        dep_success = {"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}]}}
-        svc_domains = {"service": {"serviceInstances": {"edges": [{"node": {"domains": {
-            "customDomains": [{"domain": "api.example.com"}],
-            "serviceDomains": [{"domain": "api.up.railway.app"}],
-        }}}]}}}
+        dep_success = {
+            "deployments": {
+                "edges": [
+                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "t"}}
+                ]
+            }
+        }
+        svc_domains = {
+            "service": {
+                "serviceInstances": {
+                    "edges": [
+                        {
+                            "node": {
+                                "domains": {
+                                    "customDomains": [{"domain": "api.example.com"}],
+                                    "serviceDomains": [
+                                        {"domain": "api.up.railway.app"}
+                                    ],
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
 
         with (
             _patch_registry(reg),
@@ -1222,7 +1721,10 @@ class TestVerifyEdgeCases:
             _patch_project(),
             _patch_service_id(return_value="sid-api"),
             _patch_gql(dep_success, svc_domains),
-            patch("railguey.lib.orchestrate.httpx.AsyncClient", new=_fake_client_factory([200, 200])),
+            patch(
+                "railguey.lib.orchestrate.httpx.AsyncClient",
+                new=_fake_client_factory([200, 200]),
+            ),
             patch("railguey.lib.orchestrate.asyncio.sleep", new_callable=AsyncMock),
         ):
             result = await verify("api", workspace=str(workspace_with_token))
@@ -1235,7 +1737,13 @@ class TestVerifyEdgeCases:
         """Exception in Railway API calls produces error check."""
         reg = {
             "defaults": {"verify": {"timeout_seconds": 5, "poll_interval_seconds": 0}},
-            "services": [{"name": "api", "type": "railway_service", "workspace": str(workspace_with_token)}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                }
+            ],
         }
         with (
             _patch_registry(reg),
@@ -1243,7 +1751,9 @@ class TestVerifyEdgeCases:
         ):
             result = await verify("api", workspace=str(workspace_with_token))
         assert result["pass"] is False
-        assert any(c["check"] == "verify" and c["status"] == "error" for c in result["checks"])
+        assert any(
+            c["check"] == "verify" and c["status"] == "error" for c in result["checks"]
+        )
 
 
 # ===================================================================
@@ -1258,17 +1768,27 @@ class TestFlawDetection:
     tests once the flaws are fixed.
     """
 
-    async def test_concurrency_skip_emitted_when_service_id_none(self, workspace_with_token):
+    async def test_concurrency_skip_emitted_when_service_id_none(
+        self, workspace_with_token
+    ):
         """FIX VERIFIED: When _resolve_service_id returns None, the concurrency
         check now emits a 'skip' status so the caller knows it didn't run.
         """
         reg = {
             "defaults": {"preflight": {"require_clean_worktree": True}},
-            "services": [{"name": "api", "type": "railway_service",
-                          "workspace": str(workspace_with_token), "deploy": {"branch": "main"}}],
+            "services": [
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                }
+            ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -1291,7 +1811,9 @@ class TestFlawDetection:
         assert concurrency[0]["status"] == "skip"
         assert "not found" in concurrency[0]["detail"]
 
-    async def test_no_workspace_on_required_dep_blocks_preflight(self, workspace_with_token):
+    async def test_no_workspace_on_required_dep_blocks_preflight(
+        self, workspace_with_token
+    ):
         """FIX VERIFIED: A required_before_deploy dependency on a railway_service
         with no workspace now blocks preflight with a 'fail' status.
         """
@@ -1299,17 +1821,28 @@ class TestFlawDetection:
             "defaults": {"preflight": {"require_clean_worktree": True}},
             "services": [
                 # Dependency has NO workspace
-                {"name": "dep-api", "type": "railway_service", "repo": "dep-api",
-                 "deploy": {"branch": "main"}},  # no workspace key
                 {
-                    "name": "api", "type": "railway_service", "repo": "api",
-                    "workspace": str(workspace_with_token), "deploy": {"branch": "main"},
-                    "depends_on": [{"target": "dep-api", "gate": "required_before_deploy"}],
+                    "name": "dep-api",
+                    "type": "railway_service",
+                    "repo": "dep-api",
+                    "deploy": {"branch": "main"},
+                },  # no workspace key
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "repo": "api",
+                    "workspace": str(workspace_with_token),
+                    "deploy": {"branch": "main"},
+                    "depends_on": [
+                        {"target": "dep-api", "gate": "required_before_deploy"}
+                    ],
                 },
             ],
         }
 
-        def run_side_effect(cmd, cwd=None, capture_output=None, text=None, timeout=None):
+        def run_side_effect(
+            cmd, cwd=None, capture_output=None, text=None, timeout=None
+        ):
             if cmd[:3] == ["git", "branch", "--show-current"]:
                 return _ok_proc("main\n")
             if cmd[:3] == ["git", "status", "--porcelain"]:
@@ -1330,7 +1863,9 @@ class TestFlawDetection:
 
         # FIX: go=False, dep-api check now blocks with "fail"
         assert result["go"] is False
-        dep_checks = [c for c in result["blocking"] if c["check"] == "dependency:dep-api"]
+        dep_checks = [
+            c for c in result["blocking"] if c["check"] == "dependency:dep-api"
+        ]
         assert len(dep_checks) == 1
         assert dep_checks[0]["status"] == "fail"
         assert "no workspace" in dep_checks[0]["detail"]
@@ -1342,11 +1877,21 @@ class TestFlawDetection:
         """
         reg = {
             "services": [
-                {"name": "api", "type": "railway_service", "repo": "api-repo",
-                 "deploy": {"branch": "main"}},
-                {"name": "web", "type": "railway_service", "repo": "web-repo",
-                 "deploy": {"branch": "main"},
-                 "depends_on": [{"target": "api", "gate": "recommended_before_verify"}]},
+                {
+                    "name": "api",
+                    "type": "railway_service",
+                    "repo": "api-repo",
+                    "deploy": {"branch": "main"},
+                },
+                {
+                    "name": "web",
+                    "type": "railway_service",
+                    "repo": "web-repo",
+                    "deploy": {"branch": "main"},
+                    "depends_on": [
+                        {"target": "api", "gate": "recommended_before_verify"}
+                    ],
+                },
             ]
         }
         with _patch_registry(reg):
@@ -1360,8 +1905,9 @@ class TestFlawDetection:
                 if svc["name"] == "api":
                     api_stage = stage
         assert api_stage is not None, "api should appear in some stage"
-        assert api_stage["label"] != "API and config services", \
+        assert api_stage["label"] != "API and config services", (
             "recommended dep should NOT promote service to stage 2"
+        )
 
     async def test_flaw_migration_parser_with_real_supabase_output(self):
         """Verify migration parser works with REAL supabase CLI output format.
@@ -1383,8 +1929,9 @@ class TestFlawDetection:
             if len(parts) >= 2 and parts[0] and not parts[1]:
                 unsynced.append(parts[0])
 
-        assert unsynced == ["20260312020000"], \
+        assert unsynced == ["20260312020000"], (
             f"Parser should detect local-only migration, got: {unsynced}"
+        )
 
     async def test_flaw_migration_parser_header_row_not_false_positive(self):
         """Verify header row 'Local | Remote | Time' doesn't trigger false positive."""
@@ -1400,5 +1947,6 @@ class TestFlawDetection:
             if len(parts) >= 2 and parts[0] and not parts[1]:
                 unsynced.append(parts[0])
 
-        assert unsynced == [], \
+        assert unsynced == [], (
             f"Header/separator should NOT trigger false positive, got: {unsynced}"
+        )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -22,8 +22,14 @@ class TestRunRailway:
     async def test_successful_command(self, workspace_with_token):
         proc = mock_railway_proc(stdout=b"service list output")
         with (
-            patch("railguey.lib.cli_backend.shutil.which", return_value="/usr/local/bin/railway"),
-            patch("railguey.lib.cli_backend.asyncio.create_subprocess_exec", return_value=proc),
+            patch(
+                "railguey.lib.cli_backend.shutil.which",
+                return_value="/usr/local/bin/railway",
+            ),
+            patch(
+                "railguey.lib.cli_backend.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ),
         ):
             result = await _run_railway(str(workspace_with_token), ["status", "--json"])
         assert result == {"output": "service list output"}
@@ -32,8 +38,14 @@ class TestRunRailway:
     async def test_failed_command(self, workspace_with_token):
         proc = mock_railway_proc(stdout=b"", stderr=b"not authenticated", returncode=1)
         with (
-            patch("railguey.lib.cli_backend.shutil.which", return_value="/usr/local/bin/railway"),
-            patch("railguey.lib.cli_backend.asyncio.create_subprocess_exec", return_value=proc),
+            patch(
+                "railguey.lib.cli_backend.shutil.which",
+                return_value="/usr/local/bin/railway",
+            ),
+            patch(
+                "railguey.lib.cli_backend.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ),
         ):
             result = await _run_railway(str(workspace_with_token), ["status"])
         assert "error" in result
@@ -50,10 +62,18 @@ class TestRunRailway:
         proc.communicate = slow_communicate
 
         with (
-            patch("railguey.lib.cli_backend.shutil.which", return_value="/usr/local/bin/railway"),
-            patch("railguey.lib.cli_backend.asyncio.create_subprocess_exec", return_value=proc),
+            patch(
+                "railguey.lib.cli_backend.shutil.which",
+                return_value="/usr/local/bin/railway",
+            ),
+            patch(
+                "railguey.lib.cli_backend.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ),
         ):
-            result = await _run_railway(str(workspace_with_token), ["logs"], timeout=0.1)
+            result = await _run_railway(
+                str(workspace_with_token), ["logs"], timeout=0.1
+            )
         assert "error" in result
         assert "timed out" in result["error"]
 
@@ -67,8 +87,14 @@ class TestRunRailway:
             return proc
 
         with (
-            patch("railguey.lib.cli_backend.shutil.which", return_value="/usr/local/bin/railway"),
-            patch("railguey.lib.cli_backend.asyncio.create_subprocess_exec", side_effect=capture_exec),
+            patch(
+                "railguey.lib.cli_backend.shutil.which",
+                return_value="/usr/local/bin/railway",
+            ),
+            patch(
+                "railguey.lib.cli_backend.asyncio.create_subprocess_exec",
+                side_effect=capture_exec,
+            ),
         ):
             await _run_railway(str(workspace_with_token), ["status"])
         assert captured_kwargs["env"]["RAILWAY_TOKEN"] == "test-token-123"
@@ -83,8 +109,14 @@ class TestRunRailway:
             return proc
 
         with (
-            patch("railguey.lib.cli_backend.shutil.which", return_value="/usr/local/bin/railway"),
-            patch("railguey.lib.cli_backend.asyncio.create_subprocess_exec", side_effect=capture_exec),
+            patch(
+                "railguey.lib.cli_backend.shutil.which",
+                return_value="/usr/local/bin/railway",
+            ),
+            patch(
+                "railguey.lib.cli_backend.asyncio.create_subprocess_exec",
+                side_effect=capture_exec,
+            ),
         ):
             await _run_railway(str(workspace_with_token), ["status"])
         expected = str(Path(str(workspace_with_token)).resolve())

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,9 +9,22 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from railguey.lib.tools import (
-    status, logs, deploy, variables, variable_set, services,
-    redeploy, restart, domain, environment_create, deployments,
-    rollback, service_info, http_logs, deployment_logs, unlink_repo,
+    status,
+    logs,
+    deploy,
+    variables,
+    variable_set,
+    services,
+    redeploy,
+    restart,
+    domain,
+    environment_create,
+    deployments,
+    rollback,
+    service_info,
+    http_logs,
+    deployment_logs,
+    unlink_repo,
     service_update,
 )
 
@@ -21,11 +34,7 @@ from railguey.lib.tools import (
 
 PROJECT = {"projectId": "proj-abc", "environmentId": "env-xyz"}
 
-DEPLOYMENT_EDGES = {
-    "deployments": {
-        "edges": [{"node": {"id": "dep-001"}}]
-    }
-}
+DEPLOYMENT_EDGES = {"deployments": {"edges": [{"node": {"id": "dep-001"}}]}}
 
 DEPLOYMENT_EDGES_EMPTY = {"deployments": {"edges": []}}
 
@@ -87,7 +96,9 @@ class TestStatus:
                                                 "environmentId": "env-xyz",
                                                 "startCommand": "node start",
                                                 "domains": {
-                                                    "serviceDomains": [{"domain": "web.up.railway.app"}],
+                                                    "serviceDomains": [
+                                                        {"domain": "web.up.railway.app"}
+                                                    ],
                                                     "customDomains": [],
                                                 },
                                                 "latestDeployment": {
@@ -130,7 +141,13 @@ class TestStatus:
                                 "name": "web",
                                 "serviceInstances": {
                                     "edges": [
-                                        {"node": {"environmentId": "env-OTHER", "domains": {}, "latestDeployment": None}},
+                                        {
+                                            "node": {
+                                                "environmentId": "env-OTHER",
+                                                "domains": {},
+                                                "latestDeployment": None,
+                                            }
+                                        },
                                     ]
                                 },
                             }
@@ -158,7 +175,9 @@ class TestStatus:
         gql_response = {
             "project": {
                 "name": "proj",
-                "environments": {"edges": [{"node": {"id": "env-xyz", "name": "prod"}}]},
+                "environments": {
+                    "edges": [{"node": {"id": "env-xyz", "name": "prod"}}]
+                },
                 "services": {
                     "edges": [
                         {
@@ -167,7 +186,13 @@ class TestStatus:
                                 "name": "web",
                                 "serviceInstances": {
                                     "edges": [
-                                        {"node": {"environmentId": "env-xyz", "domains": {}, "latestDeployment": None}},
+                                        {
+                                            "node": {
+                                                "environmentId": "env-xyz",
+                                                "domains": {},
+                                                "latestDeployment": None,
+                                            }
+                                        },
                                     ]
                                 },
                             }
@@ -190,11 +215,23 @@ class TestLogs:
     async def test_deploy_logs(self, workspace_with_token):
         log_entries = {
             "deploymentLogs": [
-                {"message": "Starting server", "timestamp": "2026-01-01T00:00:00Z", "severity": "info"},
-                {"message": "Listening on :3000", "timestamp": "2026-01-01T00:00:01Z", "severity": "info"},
+                {
+                    "message": "Starting server",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "severity": "info",
+                },
+                {
+                    "message": "Listening on :3000",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "severity": "info",
+                },
             ]
         }
-        with _patch_project(), _patch_service_id(), _patch_gql(DEPLOYMENT_EDGES, log_entries):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(DEPLOYMENT_EDGES, log_entries),
+        ):
             result = await logs(str(workspace_with_token), "web")
         assert result["count"] == 2
         assert result["service"] == "web"
@@ -204,18 +241,29 @@ class TestLogs:
     async def test_build_logs(self, workspace_with_token):
         log_entries = {
             "buildLogs": [
-                {"message": "Building...", "timestamp": "2026-01-01T00:00:00Z", "severity": "info"},
+                {
+                    "message": "Building...",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "severity": "info",
+                },
             ]
         }
-        with _patch_project(), _patch_service_id(), _patch_gql(DEPLOYMENT_EDGES, log_entries):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(DEPLOYMENT_EDGES, log_entries),
+        ):
             result = await logs(str(workspace_with_token), "web", build=True)
         assert result["count"] == 1
         assert result["logs"][0]["message"] == "Building..."
 
     async def test_with_filter(self, workspace_with_token):
         log_entries = {"deploymentLogs": []}
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(DEPLOYMENT_EDGES, log_entries) as mock_gql:
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(DEPLOYMENT_EDGES, log_entries) as mock_gql,
+        ):
             await logs(str(workspace_with_token), "web", filter="ERROR")
         # Second call should include filter in variables
         _, call_kwargs = mock_gql.call_args_list[1]
@@ -223,8 +271,11 @@ class TestLogs:
 
     async def test_with_lines(self, workspace_with_token):
         log_entries = {"deploymentLogs": []}
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(DEPLOYMENT_EDGES, log_entries) as mock_gql:
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(DEPLOYMENT_EDGES, log_entries) as mock_gql,
+        ):
             await logs(str(workspace_with_token), "web", lines=50)
         # Second _gql call should pass limit=50
         args = mock_gql.call_args_list[1]
@@ -251,8 +302,11 @@ class TestLogs:
 
 class TestDeploy:
     async def test_happy_path(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql({"serviceInstanceRedeploy": True}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql({"serviceInstanceRedeploy": True}),
+        ):
             result = await deploy(str(workspace_with_token), "web")
         assert result["deployed"] is True
         assert result["service"] == "web"
@@ -263,8 +317,11 @@ class TestDeploy:
         assert "error" in result
 
     async def test_gql_error(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql({"error": "mutation failed"}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql({"error": "mutation failed"}),
+        ):
             result = await deploy(str(workspace_with_token), "web")
         assert result["error"] == "mutation failed"
 
@@ -276,8 +333,18 @@ class TestDeploy:
 
 class TestVariables:
     async def test_happy_path(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql({"variables": {"DATABASE_URL": "postgres://...", "NODE_ENV": "production"}}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(
+                {
+                    "variables": {
+                        "DATABASE_URL": "postgres://...",
+                        "NODE_ENV": "production",
+                    }
+                }
+            ),
+        ):
             result = await variables(str(workspace_with_token), "web")
         assert result["service"] == "web"
         assert "DATABASE_URL" in result["variables"]
@@ -295,16 +362,22 @@ class TestVariables:
 
 class TestVariableSet:
     async def test_happy_path(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql({"variableUpsert": True}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql({"variableUpsert": True}),
+        ):
             result = await variable_set(str(workspace_with_token), "web", "FOO", "bar")
         assert result["set"] is True
         assert result["key"] == "FOO"
         assert result["service"] == "web"
 
     async def test_gql_error(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql({"error": "unauthorized"}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql({"error": "unauthorized"}),
+        ):
             result = await variable_set(str(workspace_with_token), "web", "FOO", "bar")
         assert result["error"] == "unauthorized"
 
@@ -349,8 +422,11 @@ class TestRedeploy:
         redeploy_response = {
             "deploymentRedeploy": {"id": "dep-new", "status": "BUILDING"}
         }
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(DEPLOYMENT_EDGES, redeploy_response):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(DEPLOYMENT_EDGES, redeploy_response),
+        ):
             result = await redeploy(str(workspace_with_token), "web")
         assert result["redeployed"] is True
         assert result["deploymentId"] == "dep-new"
@@ -375,8 +451,11 @@ class TestRedeploy:
 
 class TestRestart:
     async def test_happy_path(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(DEPLOYMENT_EDGES, {"deploymentRestart": True}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(DEPLOYMENT_EDGES, {"deploymentRestart": True}),
+        ):
             result = await restart(str(workspace_with_token), "web")
         assert result["restarted"] is True
         assert result["deploymentId"] == "dep-001"
@@ -394,9 +473,7 @@ class TestRestart:
 
 
 EMPTY_DOMAINS = {
-    "serviceInstance": {
-        "domains": {"serviceDomains": [], "customDomains": []}
-    }
+    "serviceInstance": {"domains": {"serviceDomains": [], "customDomains": []}}
 }
 
 EXISTING_SERVICE_DOMAIN = {
@@ -420,22 +497,52 @@ EXISTING_CUSTOM_DOMAIN = {
 
 class TestDomain:
     async def test_generate_railway_domain(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EMPTY_DOMAINS, {"serviceDomainCreate": {"id": "dom-1", "domain": "web-abc.up.railway.app"}}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(
+                EMPTY_DOMAINS,
+                {
+                    "serviceDomainCreate": {
+                        "id": "dom-1",
+                        "domain": "web-abc.up.railway.app",
+                    }
+                },
+            ),
+        ):
             result = await domain(str(workspace_with_token), "web")
         assert result["domain"] == "web-abc.up.railway.app"
         assert result["custom"] is False
 
     async def test_custom_domain(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EMPTY_DOMAINS, {"customDomainCreate": {"id": "dom-2", "domain": "app.example.com"}}):
-            result = await domain(str(workspace_with_token), "web", domain="app.example.com")
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(
+                EMPTY_DOMAINS,
+                {"customDomainCreate": {"id": "dom-2", "domain": "app.example.com"}},
+            ),
+        ):
+            result = await domain(
+                str(workspace_with_token), "web", domain="app.example.com"
+            )
         assert result["domain"] == "app.example.com"
         assert result["custom"] is True
 
     async def test_with_port(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EMPTY_DOMAINS, {"serviceDomainCreate": {"id": "dom-3", "domain": "web.up.railway.app"}}) as mock_gql:
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(
+                EMPTY_DOMAINS,
+                {
+                    "serviceDomainCreate": {
+                        "id": "dom-3",
+                        "domain": "web.up.railway.app",
+                    }
+                },
+            ) as mock_gql,
+        ):
             await domain(str(workspace_with_token), "web", port=8080)
         # Verify targetPort was passed in the create call (second _gql call)
         call_args = mock_gql.call_args
@@ -443,9 +550,17 @@ class TestDomain:
         assert input_vars["targetPort"] == 8080
 
     async def test_custom_domain_with_port(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EMPTY_DOMAINS, {"customDomainCreate": {"id": "dom-4", "domain": "api.example.com"}}) as mock_gql:
-            await domain(str(workspace_with_token), "web", domain="api.example.com", port=3000)
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(
+                EMPTY_DOMAINS,
+                {"customDomainCreate": {"id": "dom-4", "domain": "api.example.com"}},
+            ) as mock_gql,
+        ):
+            await domain(
+                str(workspace_with_token), "web", domain="api.example.com", port=3000
+            )
         input_vars = mock_gql.call_args[0][2]["input"]
         assert input_vars["targetPort"] == 3000
         assert input_vars["domain"] == "api.example.com"
@@ -459,10 +574,13 @@ class TestDomain:
 
     async def test_update_existing_service_domain_port(self, workspace_with_token):
         """Existing railway.app domain + port => update targetPort via Bearer auth."""
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EXISTING_SERVICE_DOMAIN), \
-                _patch_user_token(), \
-                _patch_gql_bearer({"serviceDomainUpdate": True}) as mock_bearer:
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(EXISTING_SERVICE_DOMAIN),
+            _patch_user_token(),
+            _patch_gql_bearer({"serviceDomainUpdate": True}) as mock_bearer,
+        ):
             result = await domain(str(workspace_with_token), "web", port=8000)
         assert result["updated"] is True
         assert result["targetPort"] == 8000
@@ -477,11 +595,16 @@ class TestDomain:
 
     async def test_update_existing_custom_domain_port(self, workspace_with_token):
         """Existing custom domain + port => update targetPort via Bearer auth."""
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EXISTING_CUSTOM_DOMAIN), \
-                _patch_user_token(), \
-                _patch_gql_bearer({"customDomainUpdate": True}) as mock_bearer:
-            result = await domain(str(workspace_with_token), "web", domain="api.example.com", port=3000)
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(EXISTING_CUSTOM_DOMAIN),
+            _patch_user_token(),
+            _patch_gql_bearer({"customDomainUpdate": True}) as mock_bearer,
+        ):
+            result = await domain(
+                str(workspace_with_token), "web", domain="api.example.com", port=3000
+            )
         assert result["updated"] is True
         assert result["targetPort"] == 3000
         assert result["domain"] == "api.example.com"
@@ -492,8 +615,7 @@ class TestDomain:
 
     async def test_existing_domain_no_port_returns_info(self, workspace_with_token):
         """Existing domain + no port => just return existing domain info."""
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EXISTING_SERVICE_DOMAIN):
+        with _patch_project(), _patch_service_id(), _patch_gql(EXISTING_SERVICE_DOMAIN):
             result = await domain(str(workspace_with_token), "web")
         assert result["existing"] is True
         assert result["domain"] == "web-abc.up.railway.app"
@@ -502,19 +624,25 @@ class TestDomain:
 
     async def test_update_domain_no_account_token(self, workspace_with_token):
         """Update requires Bearer token — error if no account registered."""
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EXISTING_SERVICE_DOMAIN), \
-                _patch_user_token_missing():
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(EXISTING_SERVICE_DOMAIN),
+            _patch_user_token_missing(),
+        ):
             result = await domain(str(workspace_with_token), "web", port=8000)
         assert "error" in result
         assert "Bearer" in result["error"]
 
     async def test_update_domain_gql_error(self, workspace_with_token):
         """GraphQL error during update passes through."""
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(EXISTING_SERVICE_DOMAIN), \
-                _patch_user_token(), \
-                _patch_gql_bearer({"error": "unauthorized"}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(EXISTING_SERVICE_DOMAIN),
+            _patch_user_token(),
+            _patch_gql_bearer({"error": "unauthorized"}),
+        ):
             result = await domain(str(workspace_with_token), "web", port=8000)
         assert result["error"] == "unauthorized"
 
@@ -526,8 +654,10 @@ class TestDomain:
 
 class TestEnvironmentCreate:
     async def test_happy_path(self, workspace_with_token):
-        with _patch_project(), \
-                _patch_gql({"environmentCreate": {"id": "env-new", "name": "staging"}}):
+        with (
+            _patch_project(),
+            _patch_gql({"environmentCreate": {"id": "env-new", "name": "staging"}}),
+        ):
             result = await environment_create(str(workspace_with_token), "staging")
         assert result["created"] is True
         assert result["name"] == "staging"
@@ -549,10 +679,28 @@ class TestDeployments:
         gql_response = {
             "deployments": {
                 "edges": [
-                    {"node": {"id": "dep-1", "status": "SUCCESS", "createdAt": "2026-01-01T00:00:00Z",
-                              "url": None, "staticUrl": None, "canRedeploy": True, "canRollback": True}},
-                    {"node": {"id": "dep-2", "status": "FAILED", "createdAt": "2025-12-31T00:00:00Z",
-                              "url": None, "staticUrl": None, "canRedeploy": True, "canRollback": False}},
+                    {
+                        "node": {
+                            "id": "dep-1",
+                            "status": "SUCCESS",
+                            "createdAt": "2026-01-01T00:00:00Z",
+                            "url": None,
+                            "staticUrl": None,
+                            "canRedeploy": True,
+                            "canRollback": True,
+                        }
+                    },
+                    {
+                        "node": {
+                            "id": "dep-2",
+                            "status": "FAILED",
+                            "createdAt": "2025-12-31T00:00:00Z",
+                            "url": None,
+                            "staticUrl": None,
+                            "canRedeploy": True,
+                            "canRollback": False,
+                        }
+                    },
                 ]
             }
         }
@@ -563,8 +711,11 @@ class TestDeployments:
         assert result["deployments"][1]["canRollback"] is False
 
     async def test_respects_limit(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql({"deployments": {"edges": []}}) as mock_gql:
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql({"deployments": {"edges": []}}) as mock_gql,
+        ):
             await deployments(str(workspace_with_token), "web", limit=5)
         call_args = mock_gql.call_args[0][2]
         assert call_args["first"] == 5
@@ -606,7 +757,12 @@ class TestServiceInfo:
                 "numReplicas": 1,
                 "restartPolicyType": "ON_FAILURE",
                 "restartPolicyMaxRetries": 10,
-                "latestDeployment": {"id": "dep-1", "status": "SUCCESS", "createdAt": "2026-01-01", "url": None},
+                "latestDeployment": {
+                    "id": "dep-1",
+                    "status": "SUCCESS",
+                    "createdAt": "2026-01-01",
+                    "url": None,
+                },
             }
         }
         with _patch_project(), _patch_service_id(), _patch_gql(instance_data):
@@ -626,20 +782,32 @@ class TestHttpLogs:
     async def test_with_deployment_id(self, workspace_with_token):
         log_data = {
             "httpLogs": [
-                {"timestamp": "2026-01-01T00:00:00Z", "method": "GET", "path": "/",
-                 "httpStatus": 200, "totalDuration": 12, "requestId": "r1", "srcIp": "1.2.3.4"},
+                {
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "method": "GET",
+                    "path": "/",
+                    "httpStatus": 200,
+                    "totalDuration": 12,
+                    "requestId": "r1",
+                    "srcIp": "1.2.3.4",
+                },
             ]
         }
         with _patch_gql(log_data):
-            result = await http_logs(str(workspace_with_token), "web", deployment_id="dep-001")
+            result = await http_logs(
+                str(workspace_with_token), "web", deployment_id="dep-001"
+            )
         assert result["count"] == 1
         assert result["logs"][0]["httpStatus"] == 200
         assert result["deployment_id"] == "dep-001"
 
     async def test_auto_resolve_deployment(self, workspace_with_token):
         log_data = {"httpLogs": []}
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql(DEPLOYMENT_EDGES, log_data):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql(DEPLOYMENT_EDGES, log_data),
+        ):
             result = await http_logs(str(workspace_with_token), "web")
         assert result["deployment_id"] == "dep-001"
         assert result["count"] == 0
@@ -659,8 +827,16 @@ class TestDeploymentLogs:
     async def test_deploy_logs(self, workspace_with_token):
         log_entries = {
             "deploymentLogs": [
-                {"message": "Starting server", "timestamp": "2026-01-01T00:00:00Z", "severity": "info"},
-                {"message": "Listening on :3000", "timestamp": "2026-01-01T00:00:01Z", "severity": "info"},
+                {
+                    "message": "Starting server",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "severity": "info",
+                },
+                {
+                    "message": "Listening on :3000",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "severity": "info",
+                },
             ]
         }
         with _patch_gql(log_entries):
@@ -672,11 +848,17 @@ class TestDeploymentLogs:
     async def test_build_logs(self, workspace_with_token):
         log_entries = {
             "buildLogs": [
-                {"message": "Installing deps...", "timestamp": "2026-01-01T00:00:00Z", "severity": "info"},
+                {
+                    "message": "Installing deps...",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "severity": "info",
+                },
             ]
         }
         with _patch_gql(log_entries):
-            result = await deployment_logs(str(workspace_with_token), "dep-123", build=True)
+            result = await deployment_logs(
+                str(workspace_with_token), "dep-123", build=True
+            )
         assert result["count"] == 1
         assert result["logs"][0]["message"] == "Installing deps..."
 
@@ -709,8 +891,11 @@ class TestDeploymentLogs:
 
 class TestUnlinkRepo:
     async def test_happy_path(self, workspace_with_token):
-        with _patch_project(), _patch_service_id(), \
-                _patch_gql({"serviceDisconnect": {"id": "svc-111"}}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_gql({"serviceDisconnect": {"id": "svc-111"}}),
+        ):
             result = await unlink_repo(str(workspace_with_token), "web")
         assert result["disconnected"] is True
         assert result["service"] == "web"
@@ -764,9 +949,15 @@ def _patch_user_token_missing():
 class TestServiceUpdate:
     async def test_set_healthcheck(self, workspace_with_token):
         """Happy path: set a single field (healthcheckPath)."""
-        with _patch_project(), _patch_service_id(), _patch_user_token(), \
-                _patch_gql_bearer({"serviceInstanceUpdate": True}) as mock_bearer:
-            result = await service_update(str(workspace_with_token), "web", healthcheck_path="/health")
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_user_token(),
+            _patch_gql_bearer({"serviceInstanceUpdate": True}) as mock_bearer,
+        ):
+            result = await service_update(
+                str(workspace_with_token), "web", healthcheck_path="/health"
+            )
         assert result["updated"] is True
         assert result["service"] == "web"
         assert result["fields"] == {"healthcheckPath": "/health"}
@@ -780,10 +971,15 @@ class TestServiceUpdate:
 
     async def test_multiple_fields(self, workspace_with_token):
         """Set multiple fields at once."""
-        with _patch_project(), _patch_service_id(), _patch_user_token(), \
-                _patch_gql_bearer({"serviceInstanceUpdate": True}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_user_token(),
+            _patch_gql_bearer({"serviceInstanceUpdate": True}),
+        ):
             result = await service_update(
-                str(workspace_with_token), "web",
+                str(workspace_with_token),
+                "web",
                 healthcheck_path="/health",
                 start_command="node server.js",
                 num_replicas=2,
@@ -806,7 +1002,9 @@ class TestServiceUpdate:
     async def test_no_account_token_error(self, workspace_with_token):
         """Error when no account token is available."""
         with _patch_project(), _patch_service_id(), _patch_user_token_missing():
-            result = await service_update(str(workspace_with_token), "web", healthcheck_path="/health")
+            result = await service_update(
+                str(workspace_with_token), "web", healthcheck_path="/health"
+            )
         assert "error" in result
         assert "Bearer" in result["error"]
         assert "account" in result["error"]
@@ -814,29 +1012,44 @@ class TestServiceUpdate:
     async def test_service_not_found(self, workspace_with_token):
         """Error when service name doesn't match any service."""
         with _patch_project(), _patch_service_id(None):
-            result = await service_update(str(workspace_with_token), "ghost", healthcheck_path="/health")
+            result = await service_update(
+                str(workspace_with_token), "ghost", healthcheck_path="/health"
+            )
         assert "error" in result
         assert "ghost" in result["error"]
 
     async def test_project_error_passthrough(self, workspace_with_token):
         """Project resolution errors pass through."""
         with _patch_project({"error": "bad token"}):
-            result = await service_update(str(workspace_with_token), "web", healthcheck_path="/health")
+            result = await service_update(
+                str(workspace_with_token), "web", healthcheck_path="/health"
+            )
         assert result == {"error": "bad token"}
 
     async def test_gql_bearer_error(self, workspace_with_token):
         """GraphQL mutation errors pass through."""
-        with _patch_project(), _patch_service_id(), _patch_user_token(), \
-                _patch_gql_bearer({"error": "unauthorized"}):
-            result = await service_update(str(workspace_with_token), "web", healthcheck_path="/health")
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_user_token(),
+            _patch_gql_bearer({"error": "unauthorized"}),
+        ):
+            result = await service_update(
+                str(workspace_with_token), "web", healthcheck_path="/health"
+            )
         assert result["error"] == "unauthorized"
 
     async def test_all_fields(self, workspace_with_token):
         """All 8 fields can be set at once."""
-        with _patch_project(), _patch_service_id(), _patch_user_token(), \
-                _patch_gql_bearer({"serviceInstanceUpdate": True}):
+        with (
+            _patch_project(),
+            _patch_service_id(),
+            _patch_user_token(),
+            _patch_gql_bearer({"serviceInstanceUpdate": True}),
+        ):
             result = await service_update(
-                str(workspace_with_token), "web",
+                str(workspace_with_token),
+                "web",
                 healthcheck_path="/health",
                 start_command="node start",
                 build_command="npm run build",


### PR DESCRIPTION
Closes #2

## Summary

Adds four tools for managing Railway volumes — `volume_create`, `volumes`, `volume_delete`, `volume_resize` — filling the last Railway-infra gap in railguey.

## The discovery that unblocked this

Originally I assumed volume management needed an account-scoped token (like `serviceInstanceUpdate`). Live API testing on 2026-04-15 against the real greenmark-waste-solutions project disproved that — **project-scoped tokens CAN execute `volumeCreate`, `volumeDelete`, `volumeInstanceUpdate`, and the `project.volumes` query**. All four tools use the existing `_gql()` helper with `Project-Access-Token` auth.

## New tools

| Tool | Purpose |
|---|---|
| `railguey_volume_create(workspace, service, mount_path)` | Create a volume and attach it to a service at the given mount path. Service auto-redeploys with the volume mounted. |
| `railguey_volumes(workspace)` | List all volumes in the project with their instances. |
| `railguey_volume_delete(workspace, volume_id)` | Irreversible. Matches `project_delete` pattern — destructive noted in docstring, no TOTP at the library layer (consistent with existing destructive ops). |
| `railguey_volume_resize(workspace, volume_instance_id, size_mb)` | Grow-only (Railway rejects shrink). |

## Tested end-to-end

Built `cerebro-telemetry` (new service in greenmark-waste-solutions) specifically to exercise this. Used the new tools to:

1. Create a 50 GB volume attached to `cerebro-telemetry` at `/data`
2. List it back via `volumes()` — correct shape returned
3. Flip `DB_PATH=/data/telemetry.sqlite` via `variable_set`
4. Emit a sentinel event (UUID `133fd2ac-7c62-4ec0-83cc-12519b3e9c77`)
5. Restart the container via `railguey_restart`
6. Re-query — **same UUID, same attrs** → volume persistence proven
7. Re-run `cerebro-telemetry`'s 32-case live test suite → 32/32 pass

## Regression check

```
tests/ … 186 passed, 20 skipped, 6 xfailed in 0.55s
```

Zero regressions. 20 skipped are pre-existing live-integration tests (expected). 6 xfails are pre-existing (expected).

## Where the discovery is captured

The `volume_create` docstring explicitly notes:

> Uses the project-scoped token from workspace/.env.local. Confirmed 2026-04-15 that project tokens can execute volumeCreate — no account token required (unlike serviceInstanceUpdate).

This lives in the code where the next agent will read it, not in a chat thread that gets archived.

## Test plan

- [x] Run `python -m pytest tests/` locally → 186 pass
- [x] Create + list + attach a live volume via the new tools
- [x] Persistence survives a container restart
- [x] cerebro-telemetry's independent 32-case live suite still green
- [ ] Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)