### PR TITLE
fix: volume tools use project-scoped token (not account override)

### DIFF
--- a/railguey/lib/token.py
+++ b/railguey/lib/token.py
@@ -3,30 +3,15 @@
 from pathlib import Path
 
 
-def _load_token(workspace: str) -> str:
-    """Resolve a Railway token.
+def _load_project_token(workspace: str) -> str:
+    """Resolve a PROJECT-scoped Railway token from workspace .env files.
 
-    Priority:
-    1. Default account in ~/.railguey/accounts.json (if one is set)
-    2. RAILWAY_TOKEN in workspace/.env.local (then .env as fallback)
-
-    The account system acts as an explicit override — when you call
-    railguey_account_default('production'), ALL tools switch to the
-    production token regardless of what's in .env.local. This is the
-    core use case: briefly operate on a different environment without
-    swapping .env files.
-
-    When no account is configured, falls back to workspace .env files.
+    Skips the account system entirely. Some Railway GraphQL mutations
+    (volumeCreate, volumeDelete, volumeInstanceUpdate) require a
+    project-scoped token and reject account tokens with
+    "Project Token not found" — for those, call this function instead
+    of _load_token.
     """
-    # 1. Account system override
-    try:
-        from railguey.lib.accounts import get_account_token
-
-        return get_account_token()
-    except (ValueError, ImportError):
-        pass
-
-    # 2. Workspace .env files
     ws = Path(workspace).expanduser().resolve()
     for filename in (".env.local", ".env"):
         envfile = ws / filename
@@ -44,6 +29,35 @@ def _load_token(workspace: str) -> str:
                 if value:
                     return value
     raise ValueError(
-        f"No Railway token found. Use railguey_account_add to register an account, "
-        f"or add RAILWAY_TOKEN to {ws}/.env.local."
+        f"No project-scoped Railway token found. Add RAILWAY_TOKEN to {ws}/.env.local."
     )
+
+
+def _load_token(workspace: str) -> str:
+    """Resolve a Railway token.
+
+    Priority:
+    1. Default account in ~/.railguey/accounts.json (if one is set)
+    2. RAILWAY_TOKEN in workspace/.env.local (then .env as fallback)
+
+    The account system acts as an explicit override — when you call
+    railguey_account_default('production'), ALL tools switch to the
+    production token regardless of what's in .env.local. This is the
+    core use case: briefly operate on a different environment without
+    swapping .env files.
+
+    When no account is configured, falls back to workspace .env files.
+
+    NOTE: Volume mutations require a project-scoped token — use
+    _load_project_token() instead for those.
+    """
+    # 1. Account system override
+    try:
+        from railguey.lib.accounts import get_account_token
+
+        return get_account_token()
+    except (ValueError, ImportError):
+        pass
+
+    # 2. Workspace .env files (fall back to project-token reader)
+    return _load_project_token(workspace)

--- a/railguey/lib/tools.py
+++ b/railguey/lib/tools.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from pathlib import Path
 
-from railguey.lib.token import _load_token
+from railguey.lib.token import _load_project_token, _load_token
 from railguey.lib.graphql import (
     _gql,
     _gql_bearer,
@@ -1411,7 +1411,7 @@ async def volume_create(
     After creation the service redeploys automatically with the volume
     mounted at `mount_path`.
     """
-    token = _load_token(workspace)
+    token = _load_project_token(workspace)
     project = await _resolve_project(token)
     if "error" in project:
         return project
@@ -1461,7 +1461,7 @@ async def volumes(workspace: str) -> dict:
 
     Returns each volume with its volume instances (one per environment).
     """
-    token = _load_token(workspace)
+    token = _load_project_token(workspace)
     project = await _resolve_project(token)
     if "error" in project:
         return project
@@ -1529,7 +1529,7 @@ async def volume_delete(
     Matches the existing project_delete pattern (no TOTP gate at the library
     layer; the destructive nature is documented in the tool docstring).
     """
-    token = _load_token(workspace)
+    token = _load_project_token(workspace)
     query = """
     mutation volumeDelete($volumeId: String!) {
       volumeDelete(volumeId: $volumeId)
@@ -1548,7 +1548,7 @@ async def volume_resize(
 ) -> dict:
     """Resize a volume instance to a new size (MB). Railway requires
     grow-only — you can increase but not shrink."""
-    token = _load_token(workspace)
+    token = _load_project_token(workspace)
     project = await _resolve_project(token)
     if "error" in project:
         return project


### PR DESCRIPTION
## Summary
- Adds \`_load_project_token(workspace)\` helper that reads \`RAILWAY_TOKEN\` only from \`workspace/.env.local\` / \`.env\`, skipping the account system.
- Switches the 4 volume tools (\`volume_create\`, \`volumes\`, \`volume_delete\`, \`volume_resize\`) to use it.
- \`_load_token\` falls back to \`_load_project_token\` for the non-account case, preserving all existing behavior.

## Why
Railway's \`volumeCreate\` / \`volumeDelete\` / \`volumeInstanceUpdate\` mutations require a project-scoped token and reject account tokens with \"Project Token not found\" — even when the account has workspace access. Before this fix, any user with a default account set via \`railguey_account_default\` couldn't use the volume tools at all.

## Test plan
- [x] \`volumes()\` against a real Railway project succeeds with an eidos account set as default (previously failed).
- [x] Imports still resolve (\`from railguey.lib.token import _load_token, _load_project_token\`).
- [ ] CI is green.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)