### PR TITLE
fix: CLI exits non-zero when tool result carries an error (v0.2.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.10 — CLI exit-non-zero on tool error (was silently passing in CI)
+
+- **Fixed**: `_output()` now exits with code 1 when the tool result dict contains an `"error"` key. Previously, every CLI verb returned exit code 0 regardless of whether the underlying API call succeeded — meaning `gh actions` showing green for `railguey upload-source` deploys that actually 404'd. Caught 2026-05-02 in `data-daemon-v4-test`'s GHA workflow: `Upload failed (HTTP 404): Service instance not found` was emitted as JSON to stdout, but the GHA step succeeded, masking a real deploy failure (in this case, dd4t-bootstrapped-in-production-but-token-was-develop, but that's unrelated to the exit-code bug). Any pipeline that consumes railguey JSON via `--json` was unaffected; pipelines that just check exit codes were broken.
+- **Cross-ref**: `cerebro-wiki/wiki/architecture/railway-first-deploy.md` updated to reflect that "fresh service deploy" diagnosis can also surface as a cross-environment-token mismatch.
+
 ## v0.2.9 — First-deploy substrate: service-bootstrap + upload-source + service-delete
 
 - **Fixed**: `service_create` now passes `environmentId` (was creating unusable services). Railway's schema requires it to materialize the per-env service-instance binding. Without it, every subsequent `POST /up` returned 404 "Service instance not found." Discovered 2026-05-02 while bootstrapping `data-daemon-v4-test`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "railguey"
-version = "0.2.9"
+version = "0.2.10"
 description = "Project-scoped Railway MCP server — reads RAILWAY_TOKEN from .env.local, no login needed"
 readme = "README.md"
 license = "MIT"

--- a/railguey/cli.py
+++ b/railguey/cli.py
@@ -8,6 +8,7 @@ Usage:
 
 import asyncio
 import json
+import sys
 
 import click
 
@@ -21,8 +22,17 @@ def _run(coro):
 
 
 def _output(result: dict):
-    """Pretty-print a tool result as JSON."""
+    """Pretty-print a tool result as JSON, exit non-zero if it carries an error.
+
+    The "error" key is railguey's convention for tool-call failure (HTTP non-2xx,
+    GraphQL errors, missing credentials, etc.). Without this exit-non-zero
+    behavior, CI workflows that pipe `railguey <verb>` to a step succeed even
+    when Railway returned a 404 — silently masking failed deploys.
+    Caught 2026-05-02 when GHA showed green for an `upload-source` that 404'd.
+    """
     click.echo(json.dumps(result, indent=2))
+    if isinstance(result, dict) and "error" in result:
+        sys.exit(1)
 
 
 @click.group()


### PR DESCRIPTION
Closes #11.

## Summary

CLI verbs print error JSON to stdout but exit 0 — masks broken deploys in CI.

Caught 2026-05-02 in data-daemon-v4-test: \`railguey upload-source\` returned \`Upload failed (HTTP 404): Service instance not found\` and the GHA step still succeeded.

## Fix

\`_output()\` now \`sys.exit(1)\` when the result dict carries an \`"error"\` key.

## Verified locally

\`\`\`
$ HOME=/tmp/no-accounts railguey upload-source /tmp/citest-clean dd4t --message exit-test
{
  "error": "Upload failed (HTTP 404): Service instance not found",
  ...
}
$ echo \$?
1
\`\`\`

Ships as v0.2.10. CHANGELOG entry included; publish.yml's grep-validation will pass.

## Test plan

- [x] Reproduce 0-exit-on-error pre-fix
- [x] Verify 1-exit post-fix
- [x] Lint clean (ruff check + format)
- [x] CHANGELOG header matches \`version\` in pyproject.toml