### PR TITLE
feat: wire 4 volume CLI verbs (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.3.1 — Volume CLI verbs + FOSS hygiene
 
+- **Added**: 4 CLI verbs wrapping the existing volume tools — `railguey volume-create <workspace> <service> <mount-path>`, `railguey volumes <workspace>`, `railguey volume-delete <workspace> <volume-id>`, `railguey volume-resize <workspace> <volume-instance-id> <size-mb>`. The underlying `volume_create` / `volumes` / `volume_delete` / `volume_resize` functions in `lib/tools.py` were merged in v0.2.x via PR #3 but never exposed as click commands; the 0.3.0 "cli-only" pivot made wiring them a substrate gap. Now closed.
+- **Cleanup**: Retired the stale `fix/volume-tools-use-project-token` branch (forked from v0.2.7, predating v0.2.9). Its intent — volume tools should call `_load_project_token` not `_load_token` — already merged on main; verified locally for all 4 volume functions.
 - **FOSS hygiene**: Updated the forge manifest to match the public repository, refreshed stale PyPI release instructions, and removed old `0.2.x` release-plan language.
 - **Docs**: Replaced public GitHub Actions examples that still installed the official Railway CLI with `pip install railguey` and `railguey upload-source`.
 - **Packaging docs**: README now uses a public absolute logo URL so the logo renders on PyPI as well as GitHub.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "railguey"
-version = "0.3.0"
+version = "0.3.1"
 description = "Project-scoped Railway CLI — reads RAILWAY_TOKEN from .env.local, no login needed"
 readme = "README.md"
 license = "MIT"

--- a/railguey/cli.py
+++ b/railguey/cli.py
@@ -169,6 +169,44 @@ def service_delete(workspace, service):
     _output(_run(tools.service_delete(workspace, service)))
 
 
+@main.command("volume-create")
+@click.argument("workspace")
+@click.argument("service")
+@click.argument("mount_path")
+def volume_create(workspace, service, mount_path):
+    """Create a Railway volume and attach it to a service at MOUNT_PATH.
+
+    Project-token-only. Default size is 50 GB. Service redeploys
+    automatically once the volume is attached.
+    """
+    _output(_run(tools.volume_create(workspace, service, mount_path)))
+
+
+@main.command()
+@click.argument("workspace")
+def volumes(workspace):
+    """List all volumes in the Railway project with their mount state."""
+    _output(_run(tools.volumes(workspace)))
+
+
+@main.command("volume-delete")
+@click.argument("workspace")
+@click.argument("volume_id")
+def volume_delete(workspace, volume_id):
+    """Delete a Railway volume. Irreversible — all data on the volume is lost."""
+    _output(_run(tools.volume_delete(workspace, volume_id)))
+
+
+@main.command("volume-resize")
+@click.argument("workspace")
+@click.argument("volume_instance_id")
+@click.argument("size_mb", type=int)
+def volume_resize(workspace, volume_instance_id, size_mb):
+    """Resize a volume instance to SIZE_MB megabytes. Grow-only — Railway
+    rejects shrink. Get VOLUME_INSTANCE_ID from `railguey volumes`."""
+    _output(_run(tools.volume_resize(workspace, volume_instance_id, size_mb)))
+
+
 # ---------------------------------------------------------------------------
 # GraphQL-backed commands
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #13.

## Summary

The volume_create / volumes / volume_delete / volume_resize functions in lib/tools.py have existed since v0.2.x (PR #3) but were never exposed as click commands. The 0.3.0 cli-only pivot removed the MCP backdoor that made them indirectly callable; this commit wires them as proper CLI verbs.

\`\`\`
railguey volume-create <workspace> <service> <mount-path>
railguey volumes <workspace>
railguey volume-delete <workspace> <volume-id>
railguey volume-resize <workspace> <volume-instance-id> <size-mb>
\`\`\`

## Why now

Needed for the cerebro-ops-postgres provisioning flow downstream (Postgres on Railway with persisted volume for Dagster run-storage). Without these verbs the substrate gap blocks the next iteration.

## Verified locally

\`\`\`
$ uv tool install --reinstall .
$ railguey --version
railguey, version 0.3.1
$ railguey volumes --help
Usage: railguey volumes [OPTIONS] WORKSPACE
  List all volumes in the Railway project with their mount state.
$ railguey volume-create --help
Usage: railguey volume-create [OPTIONS] WORKSPACE SERVICE MOUNT_PATH
\`\`\`

ruff check + ruff format both clean on tracked files.

## Side effect

Retires the stale \`fix/volume-tools-use-project-token\` branch (forked from v0.2.7, predating v0.2.9). Its intent — volume tools should call \`_load_project_token\` not \`_load_token\` — already merged on main; verified for all 4 volume functions.

## Test plan

- [x] CLI verbs callable post-install
- [x] Help text renders for each verb
- [x] ruff check + format clean
- [x] CHANGELOG header matches \`version\` in pyproject.toml (publish.yml grep-validation will pass)