### PR TITLE
feat: research — ask Railway's own agent via ssh railway.new

### DIFF
--- a/.telos/config.yaml
+++ b/.telos/config.yaml
@@ -1,0 +1,3 @@
+id: "8dabba3d-85ce-4d99-895e-6380e58cb307"
+project: "railguey"
+created: "2026-07-04T02:48:09.031904+00:00"

--- a/.telos/north_stars/ns_b1e40bdf0c88.yaml
+++ b/.telos/north_stars/ns_b1e40bdf0c88.yaml
@@ -1,0 +1,11 @@
+id: "ns_b1e40bdf0c88"
+project_id: "8dabba3d-85ce-4d99-895e-6380e58cb307"
+goal: "Project-scoped Railway control for safe CI/CD and AI agents: read RAILWAY_TOKEN from .env.local (no interactive login), every mutating op auditable and fails loud (non-zero on tool error). Now also: vendor product research by driving Railway's own ssh agent via emux."
+metric: "Commands are project-token-scoped; tool failures exit non-zero; research reuses emux (no bespoke TUI driving)."
+stop_max_iters: null
+stop_zero_delta_n: 3
+signature: null
+created_at: "2026-07-04T02:48:09.032577+00:00"
+closed_at: null
+outcome: null
+repo_path: "/Users/dshanklinbv/repos-eidos-agi/railguey"

--- a/railguey/cli.py
+++ b/railguey/cli.py
@@ -352,22 +352,28 @@ def doctor(workspace):
 @click.argument("question")
 @click.option("--settle", default=3.0, help="Reply is done once the agent's TUI is unchanged this long (s).")
 @click.option("--max", "max_seconds", default=90.0, help="Hard cap on total wait (s).")
-@click.option("--keep-session", is_flag=True, help="Leave the ssh railway.new tmux session open afterward.")
-def research(question, settle, max_seconds, keep_session):
+@click.option("--reset", is_flag=True, help="Start a fresh conversation (drop prior context).")
+@click.option("--close", is_flag=True, help="Close the chat session after answering (default: keep it open for follow-ups).")
+def research(question, settle, max_seconds, reset, close):
     """Ask Railway's own agent a QUESTION via `ssh railway.new`.
 
-    Product research from the vendor's agent: spins up a throwaway tmux session
-    running the railway.new agent chat, asks QUESTION, waits for the reply to
-    settle, and prints the answer. The ask-and-wait step is handled by `emux ask`
-    (emux's "talk to another AI through its TUI" primitive), so tmux + emux must
-    be on PATH.
+    Product research from the vendor's agent. The chat session PERSISTS across
+    calls, so the agent keeps context — ask a follow-up and it remembers. Use
+    --reset to start over, --close to end the session.
+
+    Navigation to the agent prompt is model-driven (`emux navigate`); the Q&A is
+    `emux ask` (settle-based). Both need tmux + emux on PATH.
 
     Examples:
         railguey research "How do I add a cron schedule to a service?"
-        railguey research "What regions can I deploy to?" --settle 4
+        railguey research "and how do I see its logs?"        # follow-up, same context
+        railguey research "What regions can I deploy to?" --reset
     """
     from railguey.lib import research as research_lib
-    _output(research_lib.research(question, settle=settle, max_seconds=max_seconds, keep_session=keep_session))
+    _output(research_lib.research(
+        question, settle=settle, max_seconds=max_seconds,
+        reset=reset, keep_session=not close,
+    ))
 
 
 @main.group()

--- a/railguey/cli.py
+++ b/railguey/cli.py
@@ -350,10 +350,20 @@ def doctor(workspace):
 
 @main.command()
 @click.argument("question")
-@click.option("--settle", default=3.0, help="Reply is done once the agent's TUI is unchanged this long (s).")
+@click.option(
+    "--settle",
+    default=3.0,
+    help="Reply is done once the agent's TUI is unchanged this long (s).",
+)
 @click.option("--max", "max_seconds", default=90.0, help="Hard cap on total wait (s).")
-@click.option("--reset", is_flag=True, help="Start a fresh conversation (drop prior context).")
-@click.option("--close", is_flag=True, help="Close the chat session after answering (default: keep it open for follow-ups).")
+@click.option(
+    "--reset", is_flag=True, help="Start a fresh conversation (drop prior context)."
+)
+@click.option(
+    "--close",
+    is_flag=True,
+    help="Close the chat session after answering (default: keep it open for follow-ups).",
+)
 def research(question, settle, max_seconds, reset, close):
     """Ask Railway's own agent a QUESTION via `ssh railway.new`.
 
@@ -370,10 +380,16 @@ def research(question, settle, max_seconds, reset, close):
         railguey research "What regions can I deploy to?" --reset
     """
     from railguey.lib import research as research_lib
-    _output(research_lib.research(
-        question, settle=settle, max_seconds=max_seconds,
-        reset=reset, keep_session=not close,
-    ))
+
+    _output(
+        research_lib.research(
+            question,
+            settle=settle,
+            max_seconds=max_seconds,
+            reset=reset,
+            keep_session=not close,
+        )
+    )
 
 
 @main.group()
@@ -413,7 +429,9 @@ def bucket_info(workspace, bucket_name):
 @bucket.command("credentials")
 @click.argument("workspace")
 @click.argument("bucket_name")
-@click.option("--reset", is_flag=True, help="Reset S3 credentials before returning them.")
+@click.option(
+    "--reset", is_flag=True, help="Reset S3 credentials before returning them."
+)
 @click.option("--yes", is_flag=True, help="Confirm credential reset.")
 def bucket_credentials(workspace, bucket_name, reset, yes):
     """Show or reset S3-compatible bucket credentials."""

--- a/railguey/cli.py
+++ b/railguey/cli.py
@@ -348,6 +348,28 @@ def doctor(workspace):
     _output(_run(tools.doctor(workspace)))
 
 
+@main.command()
+@click.argument("question")
+@click.option("--settle", default=3.0, help="Reply is done once the agent's TUI is unchanged this long (s).")
+@click.option("--max", "max_seconds", default=90.0, help="Hard cap on total wait (s).")
+@click.option("--keep-session", is_flag=True, help="Leave the ssh railway.new tmux session open afterward.")
+def research(question, settle, max_seconds, keep_session):
+    """Ask Railway's own agent a QUESTION via `ssh railway.new`.
+
+    Product research from the vendor's agent: spins up a throwaway tmux session
+    running the railway.new agent chat, asks QUESTION, waits for the reply to
+    settle, and prints the answer. The ask-and-wait step is handled by `emux ask`
+    (emux's "talk to another AI through its TUI" primitive), so tmux + emux must
+    be on PATH.
+
+    Examples:
+        railguey research "How do I add a cron schedule to a service?"
+        railguey research "What regions can I deploy to?" --settle 4
+    """
+    from railguey.lib import research as research_lib
+    _output(research_lib.research(question, settle=settle, max_seconds=max_seconds, keep_session=keep_session))
+
+
 @main.group()
 def bucket():
     """Manage Railway storage buckets."""

--- a/railguey/lib/login.py
+++ b/railguey/lib/login.py
@@ -20,7 +20,6 @@ Design notes:
 from __future__ import annotations
 
 import asyncio
-import getpass
 import os
 import re
 import subprocess

--- a/railguey/lib/login.py
+++ b/railguey/lib/login.py
@@ -43,7 +43,9 @@ def _validate_token(token: str) -> None:
     authenticate.
     """
     if len(token) < 20:
-        raise ValueError("Token looks too short — Railway tokens are typically 30+ chars.")
+        raise ValueError(
+            "Token looks too short — Railway tokens are typically 30+ chars."
+        )
     if any(c.isspace() for c in token):
         raise ValueError("Token contains whitespace — likely a paste error.")
 
@@ -83,7 +85,9 @@ def _write_token(workspace: Path, token: str) -> Path:
         existing = envfile.read_text()
         if TOKEN_LINE_PATTERN.search(existing):
             # Replace the existing line
-            new_content = TOKEN_LINE_PATTERN.sub(f"RAILWAY_TOKEN={token}", existing, count=1)
+            new_content = TOKEN_LINE_PATTERN.sub(
+                f"RAILWAY_TOKEN={token}", existing, count=1
+            )
             # Ensure the replaced line still terminates with newline
             if not new_content.endswith("\n"):
                 new_content += "\n"

--- a/railguey/lib/popup.py
+++ b/railguey/lib/popup.py
@@ -133,7 +133,11 @@ def _tk_prompt_for_token(
     from tkinter import ttk
 
     result = TokenPromptResult(
-        token="", token_name=default_token_name, push_to_github=False, github_repo="", cancelled=True
+        token="",
+        token_name=default_token_name,
+        push_to_github=False,
+        github_repo="",
+        cancelled=True,
     )
 
     root = tk.Tk()
@@ -170,12 +174,18 @@ def _tk_prompt_for_token(
     url_entry.grid(row=2, column=1, sticky="we", **pad)
 
     # Token name (editable, defaults provided)
-    ttk.Label(root, text="Token name (for your reference):").grid(row=3, column=0, sticky="e", **pad)
+    ttk.Label(root, text="Token name (for your reference):").grid(
+        row=3, column=0, sticky="e", **pad
+    )
     name_var = tk.StringVar(value=default_token_name)
-    ttk.Entry(root, textvariable=name_var, width=50).grid(row=3, column=1, sticky="we", **pad)
+    ttk.Entry(root, textvariable=name_var, width=50).grid(
+        row=3, column=1, sticky="we", **pad
+    )
 
     # Token (masked)
-    ttk.Label(root, text="Paste token (hidden):").grid(row=4, column=0, sticky="e", **pad)
+    ttk.Label(root, text="Paste token (hidden):").grid(
+        row=4, column=0, sticky="e", **pad
+    )
     token_var = tk.StringVar()
     token_entry = ttk.Entry(root, textvariable=token_var, show="•", width=50)
     token_entry.grid(row=4, column=1, sticky="we", **pad)
@@ -189,9 +199,13 @@ def _tk_prompt_for_token(
         variable=push_var,
     ).grid(row=5, column=0, columnspan=2, sticky="w", **pad)
 
-    ttk.Label(root, text="GitHub repo (owner/repo):").grid(row=6, column=0, sticky="e", **pad)
+    ttk.Label(root, text="GitHub repo (owner/repo):").grid(
+        row=6, column=0, sticky="e", **pad
+    )
     repo_var = tk.StringVar(value=suggested_github_repo)
-    ttk.Entry(root, textvariable=repo_var, width=50).grid(row=6, column=1, sticky="we", **pad)
+    ttk.Entry(root, textvariable=repo_var, width=50).grid(
+        row=6, column=1, sticky="we", **pad
+    )
 
     # Buttons
     btn_frame = ttk.Frame(root)
@@ -314,7 +328,9 @@ def _terminal_prompt_for_token(
         )
 
     print(f"Open this URL in your browser to mint a token: {railway_token_url}")
-    print("(railguey would normally show a popup — Tk isn't available, falling back to terminal.)")
+    print(
+        "(railguey would normally show a popup — Tk isn't available, falling back to terminal.)"
+    )
     token = getpass.getpass("Paste token (hidden): ").strip()
     if not token:
         return TokenPromptResult(
@@ -330,9 +346,13 @@ def _terminal_prompt_for_token(
 
     push_repo = ""
     if suggested_github_repo:
-        push_input = input(
-            f"Also push to GitHub Actions secret on '{suggested_github_repo}'? [y/N]: "
-        ).strip().lower()
+        push_input = (
+            input(
+                f"Also push to GitHub Actions secret on '{suggested_github_repo}'? [y/N]: "
+            )
+            .strip()
+            .lower()
+        )
         if push_input == "y":
             push_repo = suggested_github_repo
 

--- a/railguey/lib/research.py
+++ b/railguey/lib/research.py
@@ -54,9 +54,14 @@ def research(
         "ssh -o StrictHostKeyChecking=no railway.new",
     ])
     try:
-        # The menu (Chat with the agent -> workspace -> project) has a variable
-        # number of steps — the highlighted default is what we want at each one,
-        # so poll and press Enter until the free-text prompt appears.
+        # NAVIGATION IS DUMB BY DESIGN (for now): we accept the highlighted
+        # DEFAULT at each menu step (Chat with agent -> first workspace -> first
+        # project) by pressing Enter until the free-text prompt appears. This is
+        # fine for project-AGNOSTIC product questions ("how do I do X on
+        # Railway"), which is the intended use. It does NOT let you target a
+        # specific workspace/project — it always takes the first-highlighted one.
+        # If you need project-specific research, add --project/--workspace flags
+        # that read each menu and select by name (see PR discussion).
         reached = False
         for _ in range(8):
             time.sleep(2)

--- a/railguey/lib/research.py
+++ b/railguey/lib/research.py
@@ -34,7 +34,9 @@ _NAV_GOAL = (
 
 
 def _tmux(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(["tmux", *args], capture_output=True, text=True, timeout=timeout)
+    return subprocess.run(
+        ["tmux", *args], capture_output=True, text=True, timeout=timeout
+    )
 
 
 def _session_exists() -> bool:
@@ -81,10 +83,19 @@ def research(
     fresh = False
     if not _session_exists():
         fresh = True
-        _tmux([
-            "new-session", "-d", "-s", _SESSION, "-x", "210", "-y", "52",
-            "ssh -o StrictHostKeyChecking=no railway.new",
-        ])
+        _tmux(
+            [
+                "new-session",
+                "-d",
+                "-s",
+                _SESSION,
+                "-x",
+                "210",
+                "-y",
+                "52",
+                "ssh -o StrictHostKeyChecking=no railway.new",
+            ]
+        )
         time.sleep(3)  # let the SSH TUI paint its first screen
 
     try:
@@ -93,29 +104,59 @@ def research(
         # preserve context).
         if not _at_prompt():
             nav = subprocess.run(
-                ["emux", "navigate", _SESSION, _NAV_GOAL,
-                 "--until", _PROMPT_MARKERS[0], "--max-steps", "12"],
-                capture_output=True, text=True, timeout=240,
+                [
+                    "emux",
+                    "navigate",
+                    _SESSION,
+                    _NAV_GOAL,
+                    "--until",
+                    _PROMPT_MARKERS[0],
+                    "--max-steps",
+                    "12",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=240,
             )
             if not _at_prompt():
-                return {"error": "could not reach the Railway agent prompt",
-                        "nav_stderr": (nav.stderr or "").strip(),
-                        "last_screen": _capture()}
+                return {
+                    "error": "could not reach the Railway agent prompt",
+                    "nav_stderr": (nav.stderr or "").strip(),
+                    "last_screen": _capture(),
+                }
 
         # Ask via emux's settle-based converse; --busy thinking keeps the agent's
         # streaming indicator from being read back as the reply.
         proc = subprocess.run(
-            ["emux", "ask", _SESSION, question,
-             "--settle", str(settle), "--max", str(max_seconds), "--busy", "thinking"],
-            capture_output=True, text=True, timeout=max_seconds + 30,
+            [
+                "emux",
+                "ask",
+                _SESSION,
+                question,
+                "--settle",
+                str(settle),
+                "--max",
+                str(max_seconds),
+                "--busy",
+                "thinking",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=max_seconds + 30,
         )
         reply_lines = [
-            ln for ln in (proc.stdout or "").splitlines()
-            if ln.strip() and ln.strip() != question.strip() and "thinking" not in ln.lower()
+            ln
+            for ln in (proc.stdout or "").splitlines()
+            if ln.strip()
+            and ln.strip() != question.strip()
+            and "thinking" not in ln.lower()
         ]
         answer = "\n".join(reply_lines).strip()
         if not answer:
-            return {"error": "no answer from the Railway agent", "stderr": (proc.stderr or "").strip()}
+            return {
+                "error": "no answer from the Railway agent",
+                "stderr": (proc.stderr or "").strip(),
+            }
         return {
             "ok": True,
             "question": question,

--- a/railguey/lib/research.py
+++ b/railguey/lib/research.py
@@ -2,12 +2,17 @@
 
 Railway ships an interactive agent at `ssh railway.new` that answers questions
 about deploys, cron, logs, and its own product from the official docs. This
-module drives that agent in a throwaway tmux session and returns its answer.
+module drives that agent and returns its answer.
 
-The actual "type a prompt, wait for the streaming TUI to stop changing, read the
-reply" step is delegated to `emux ask` — emux's reusable primitive for talking
-to another AI through its terminal UI. railguey just knows the railway.new menu
-navigation; emux knows how to converse.
+Two emux primitives do the work (emux = "talk to another AI through its TUI"):
+- `emux navigate` — model-driven: reach the agent's chat prompt through the
+  menu, letting a model pick keystrokes (handles reordering / new screens).
+- `emux ask` — send a question, wait for the streamed reply to settle, return it.
+
+The chat session is PERSISTENT across calls. The first `research()` connects and
+navigates to the prompt; later calls reuse the SAME live session, so the agent
+keeps the conversation context (follow-ups like "and for that service?" work).
+Pass reset=True (or `railguey research --reset`) to start a fresh conversation.
 """
 
 from __future__ import annotations
@@ -18,71 +23,92 @@ import time
 from typing import Any
 
 _SESSION = "railguey-research"
-# Strings that indicate we've reached the agent's free-text input.
+# Strings that indicate we're at the agent's free-text input.
 _PROMPT_MARKERS = ("Message the agent", "Ask a question")
+_NAV_GOAL = (
+    "Reach the free-text chat input where I can type a question to the Railway "
+    "agent (the screen shows 'Message the agent…' or 'Ask a question'). Choose "
+    "the option about chatting with the agent. At any workspace or project "
+    "picker, select the first / highlighted option."
+)
 
 
 def _tmux(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["tmux", *args], capture_output=True, text=True, timeout=timeout)
 
 
-def _capture(session: str, lines: int = 200) -> str:
-    r = _tmux(["capture-pane", "-t", session, "-p", "-S", f"-{lines}"])
+def _session_exists() -> bool:
+    return _tmux(["has-session", "-t", _SESSION]).returncode == 0
+
+
+def _capture(lines: int = 200) -> str:
+    r = _tmux(["capture-pane", "-t", _SESSION, "-p", "-S", f"-{lines}"])
     return r.stdout if r.returncode == 0 else ""
+
+
+def _at_prompt() -> bool:
+    return any(m in _capture() for m in _PROMPT_MARKERS)
 
 
 def research(
     question: str,
     settle: float = 3.0,
     max_seconds: float = 90.0,
-    keep_session: bool = False,
+    reset: bool = False,
+    keep_session: bool = True,
 ) -> dict[str, Any]:
     """Ask the Railway agent `question` via `ssh railway.new`; return its answer.
 
-    Requires `tmux`, `ssh`, and `emux` on PATH. Spawns a fresh session, walks the
-    menu to the agent prompt, delegates the Q&A to `emux ask`, and (unless
-    keep_session) tears the session down.
+    Reuses a persistent chat session so the agent keeps context across questions.
+    Requires `tmux`, `ssh`, and `emux` on PATH.
+
+    Args:
+        question: What to ask the agent.
+        settle: Seconds of an unchanged pane before the reply is considered done.
+        max_seconds: Hard cap on waiting for a reply.
+        reset: Tear down any existing chat and start a fresh conversation.
+        keep_session: Leave the session alive after answering (default True) so
+            the next call continues the same conversation. False closes it.
     """
     for binary in ("tmux", "ssh", "emux"):
         if shutil.which(binary) is None:
             hint = " (install: `uv tool install emux`)" if binary == "emux" else ""
             return {"error": f"{binary} not found on PATH{hint}"}
 
-    _tmux(["kill-session", "-t", _SESSION])  # clean slate if a prior run left one
-    _tmux([
-        "new-session", "-d", "-s", _SESSION, "-x", "210", "-y", "52",
-        "ssh -o StrictHostKeyChecking=no railway.new",
-    ])
-    try:
-        # NAVIGATION IS DUMB BY DESIGN (for now): we accept the highlighted
-        # DEFAULT at each menu step (Chat with agent -> first workspace -> first
-        # project) by pressing Enter until the free-text prompt appears. This is
-        # fine for project-AGNOSTIC product questions ("how do I do X on
-        # Railway"), which is the intended use. It does NOT let you target a
-        # specific workspace/project — it always takes the first-highlighted one.
-        # If you need project-specific research, add --project/--workspace flags
-        # that read each menu and select by name (see PR discussion).
-        reached = False
-        for _ in range(8):
-            time.sleep(2)
-            screen = _capture(_SESSION)
-            if any(m in screen for m in _PROMPT_MARKERS):
-                reached = True
-                break
-            _tmux(["send-keys", "-t", _SESSION, "Enter"])  # accept highlighted item
-        if not reached:
-            return {"error": "could not reach the Railway agent prompt",
-                    "last_screen": _capture(_SESSION)}
+    if reset and _session_exists():
+        _tmux(["kill-session", "-t", _SESSION])
 
-        # Hand off to emux's settle-based converse primitive. `--busy thinking`
-        # stops emux from mistaking the agent's "thinking…" indicator for the reply.
+    fresh = False
+    if not _session_exists():
+        fresh = True
+        _tmux([
+            "new-session", "-d", "-s", _SESSION, "-x", "210", "-y", "52",
+            "ssh -o StrictHostKeyChecking=no railway.new",
+        ])
+        time.sleep(3)  # let the SSH TUI paint its first screen
+
+    try:
+        # Only navigate when we're not already at the prompt — a reused session
+        # mid-conversation is already there, so we skip straight to asking (and
+        # preserve context).
+        if not _at_prompt():
+            nav = subprocess.run(
+                ["emux", "navigate", _SESSION, _NAV_GOAL,
+                 "--until", _PROMPT_MARKERS[0], "--max-steps", "12"],
+                capture_output=True, text=True, timeout=240,
+            )
+            if not _at_prompt():
+                return {"error": "could not reach the Railway agent prompt",
+                        "nav_stderr": (nav.stderr or "").strip(),
+                        "last_screen": _capture()}
+
+        # Ask via emux's settle-based converse; --busy thinking keeps the agent's
+        # streaming indicator from being read back as the reply.
         proc = subprocess.run(
             ["emux", "ask", _SESSION, question,
              "--settle", str(settle), "--max", str(max_seconds), "--busy", "thinking"],
             capture_output=True, text=True, timeout=max_seconds + 30,
         )
-        # emux's reply delta includes the echoed prompt line — drop it and any
-        # leftover busy indicator.
         reply_lines = [
             ln for ln in (proc.stdout or "").splitlines()
             if ln.strip() and ln.strip() != question.strip() and "thinking" not in ln.lower()
@@ -90,7 +116,14 @@ def research(
         answer = "\n".join(reply_lines).strip()
         if not answer:
             return {"error": "no answer from the Railway agent", "stderr": (proc.stderr or "").strip()}
-        return {"ok": True, "question": question, "answer": answer, "via": "ssh railway.new"}
+        return {
+            "ok": True,
+            "question": question,
+            "answer": answer,
+            "via": "ssh railway.new",
+            "session": _SESSION,
+            "new_conversation": fresh or reset,
+        }
     finally:
         if not keep_session:
             _tmux(["kill-session", "-t", _SESSION])

--- a/railguey/lib/research.py
+++ b/railguey/lib/research.py
@@ -1,0 +1,91 @@
+"""Product research via the Railway agent's own SSH TUI (`ssh railway.new`).
+
+Railway ships an interactive agent at `ssh railway.new` that answers questions
+about deploys, cron, logs, and its own product from the official docs. This
+module drives that agent in a throwaway tmux session and returns its answer.
+
+The actual "type a prompt, wait for the streaming TUI to stop changing, read the
+reply" step is delegated to `emux ask` — emux's reusable primitive for talking
+to another AI through its terminal UI. railguey just knows the railway.new menu
+navigation; emux knows how to converse.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from typing import Any
+
+_SESSION = "railguey-research"
+# Strings that indicate we've reached the agent's free-text input.
+_PROMPT_MARKERS = ("Message the agent", "Ask a question")
+
+
+def _tmux(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["tmux", *args], capture_output=True, text=True, timeout=timeout)
+
+
+def _capture(session: str, lines: int = 200) -> str:
+    r = _tmux(["capture-pane", "-t", session, "-p", "-S", f"-{lines}"])
+    return r.stdout if r.returncode == 0 else ""
+
+
+def research(
+    question: str,
+    settle: float = 3.0,
+    max_seconds: float = 90.0,
+    keep_session: bool = False,
+) -> dict[str, Any]:
+    """Ask the Railway agent `question` via `ssh railway.new`; return its answer.
+
+    Requires `tmux`, `ssh`, and `emux` on PATH. Spawns a fresh session, walks the
+    menu to the agent prompt, delegates the Q&A to `emux ask`, and (unless
+    keep_session) tears the session down.
+    """
+    for binary in ("tmux", "ssh", "emux"):
+        if shutil.which(binary) is None:
+            hint = " (install: `uv tool install emux`)" if binary == "emux" else ""
+            return {"error": f"{binary} not found on PATH{hint}"}
+
+    _tmux(["kill-session", "-t", _SESSION])  # clean slate if a prior run left one
+    _tmux([
+        "new-session", "-d", "-s", _SESSION, "-x", "210", "-y", "52",
+        "ssh -o StrictHostKeyChecking=no railway.new",
+    ])
+    try:
+        # The menu (Chat with the agent -> workspace -> project) has a variable
+        # number of steps — the highlighted default is what we want at each one,
+        # so poll and press Enter until the free-text prompt appears.
+        reached = False
+        for _ in range(8):
+            time.sleep(2)
+            screen = _capture(_SESSION)
+            if any(m in screen for m in _PROMPT_MARKERS):
+                reached = True
+                break
+            _tmux(["send-keys", "-t", _SESSION, "Enter"])  # accept highlighted item
+        if not reached:
+            return {"error": "could not reach the Railway agent prompt",
+                    "last_screen": _capture(_SESSION)}
+
+        # Hand off to emux's settle-based converse primitive. `--busy thinking`
+        # stops emux from mistaking the agent's "thinking…" indicator for the reply.
+        proc = subprocess.run(
+            ["emux", "ask", _SESSION, question,
+             "--settle", str(settle), "--max", str(max_seconds), "--busy", "thinking"],
+            capture_output=True, text=True, timeout=max_seconds + 30,
+        )
+        # emux's reply delta includes the echoed prompt line — drop it and any
+        # leftover busy indicator.
+        reply_lines = [
+            ln for ln in (proc.stdout or "").splitlines()
+            if ln.strip() and ln.strip() != question.strip() and "thinking" not in ln.lower()
+        ]
+        answer = "\n".join(reply_lines).strip()
+        if not answer:
+            return {"error": "no answer from the Railway agent", "stderr": (proc.stderr or "").strip()}
+        return {"ok": True, "question": question, "answer": answer, "via": "ssh railway.new"}
+    finally:
+        if not keep_session:
+            _tmux(["kill-session", "-t", _SESSION])

--- a/railguey/lib/tools.py
+++ b/railguey/lib/tools.py
@@ -2387,10 +2387,16 @@ async def _resolve_bucket(
     if "error" in topology:
         return topology
     for candidate in topology["buckets"]:
-        if candidate["id"].lower() == bucket.lower() or candidate["name"].lower() == bucket.lower():
+        if (
+            candidate["id"].lower() == bucket.lower()
+            or candidate["name"].lower() == bucket.lower()
+        ):
             return candidate
     for candidate in topology["projectBuckets"]:
-        if candidate.get("id", "").lower() == bucket.lower() or candidate.get("name", "").lower() == bucket.lower():
+        if (
+            candidate.get("id", "").lower() == bucket.lower()
+            or candidate.get("name", "").lower() == bucket.lower()
+        ):
             return {
                 "error": f"Bucket '{bucket}' exists in the project but is not deployed in this environment",
                 "bucketId": candidate.get("id", ""),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,18 @@ def _no_account_system():
 
 @pytest.fixture
 def workspace(tmp_path):
-    """Bare temporary workspace directory — no files."""
-    return tmp_path
+    """Bare temporary workspace directory — no files.
+
+    Nested one level under tmp_path so its PARENT has no siblings: _load_token
+    falls back to scanning sibling dirs for a shared RAILWAY_TOKEN, and pytest's
+    per-test tmp_paths are siblings of each other — several carry a test
+    `.env.local`. Returning bare tmp_path let that scan find those tokens, so the
+    "no token" tests non-deterministically failed to raise. An isolated parent
+    fixes it.
+    """
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    return ws
 
 
 @pytest.fixture

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -99,7 +99,9 @@ class TestLoginIntegration:
         )
         assert "error" not in result
         assert result["env_file"] == str(workspace / ".env.local")
-        assert (workspace / ".env.local").read_text() == f"RAILWAY_TOKEN={VALID_TOKEN}\n"
+        assert (
+            workspace / ".env.local"
+        ).read_text() == f"RAILWAY_TOKEN={VALID_TOKEN}\n"
 
     def test_login_rejects_invalid_token(self, workspace):
         result = login_lib.login(

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import os
 import stat
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_popup.py
+++ b/tests/test_popup.py
@@ -19,6 +19,7 @@ class TestCanUseTk:
         # On systems where tkinter is available (almost all dev machines)
         try:
             import tkinter  # noqa: F401
+
             assert popup._can_use_tk() is True
         except ImportError:
             assert popup._can_use_tk() is False
@@ -37,9 +38,14 @@ class TestTerminalPromptForToken:
         assert r.token == ""
 
     def test_uses_default_token_name_when_user_hits_enter(self):
-        with patch("sys.stdin") as fake_stdin, \
-             patch("getpass.getpass", return_value="abcdef0123456789-test-token-long-enough"), \
-             patch("builtins.input", return_value=""):
+        with (
+            patch("sys.stdin") as fake_stdin,
+            patch(
+                "getpass.getpass",
+                return_value="abcdef0123456789-test-token-long-enough",
+            ),
+            patch("builtins.input", return_value=""),
+        ):
             fake_stdin.isatty.return_value = True
             r = popup._terminal_prompt_for_token(
                 railway_token_url="https://railway.app/account/tokens",
@@ -52,9 +58,14 @@ class TestTerminalPromptForToken:
         assert r.push_to_github is False
 
     def test_accepts_user_supplied_name(self):
-        with patch("sys.stdin") as fake_stdin, \
-             patch("getpass.getpass", return_value="abcdef0123456789-test-token-long-enough"), \
-             patch("builtins.input", return_value="custom-name"):
+        with (
+            patch("sys.stdin") as fake_stdin,
+            patch(
+                "getpass.getpass",
+                return_value="abcdef0123456789-test-token-long-enough",
+            ),
+            patch("builtins.input", return_value="custom-name"),
+        ):
             fake_stdin.isatty.return_value = True
             r = popup._terminal_prompt_for_token(
                 railway_token_url="https://railway.app/account/tokens",
@@ -64,8 +75,10 @@ class TestTerminalPromptForToken:
         assert r.token_name == "custom-name"
 
     def test_cancelled_on_empty_token(self):
-        with patch("sys.stdin") as fake_stdin, \
-             patch("getpass.getpass", return_value=""):
+        with (
+            patch("sys.stdin") as fake_stdin,
+            patch("getpass.getpass", return_value=""),
+        ):
             fake_stdin.isatty.return_value = True
             r = popup._terminal_prompt_for_token(
                 railway_token_url="https://railway.app/account/tokens",
@@ -77,32 +90,47 @@ class TestTerminalPromptForToken:
 
 class TestTerminalConfirmSave:
     def test_confirms_when_user_presses_enter(self):
-        with patch("sys.stdin") as fake_stdin, \
-             patch("builtins.input", return_value=""):
+        with patch("sys.stdin") as fake_stdin, patch("builtins.input", return_value=""):
             fake_stdin.isatty.return_value = True
             r = popup._terminal_confirm_save(
-                project_name="x", project_id="p", environment_id="e",
-                team_name="t", env_file_path="/tmp/.env.local", github_repo=None,
+                project_name="x",
+                project_id="p",
+                environment_id="e",
+                team_name="t",
+                env_file_path="/tmp/.env.local",
+                github_repo=None,
             )
         assert r.confirmed is True
 
     def test_confirms_when_user_types_y(self):
-        with patch("sys.stdin") as fake_stdin, \
-             patch("builtins.input", return_value="y"):
+        with (
+            patch("sys.stdin") as fake_stdin,
+            patch("builtins.input", return_value="y"),
+        ):
             fake_stdin.isatty.return_value = True
             r = popup._terminal_confirm_save(
-                project_name="x", project_id="p", environment_id="e",
-                team_name="t", env_file_path="/tmp/.env.local", github_repo=None,
+                project_name="x",
+                project_id="p",
+                environment_id="e",
+                team_name="t",
+                env_file_path="/tmp/.env.local",
+                github_repo=None,
             )
         assert r.confirmed is True
 
     def test_cancels_on_n(self):
-        with patch("sys.stdin") as fake_stdin, \
-             patch("builtins.input", return_value="n"):
+        with (
+            patch("sys.stdin") as fake_stdin,
+            patch("builtins.input", return_value="n"),
+        ):
             fake_stdin.isatty.return_value = True
             r = popup._terminal_confirm_save(
-                project_name="x", project_id="p", environment_id="e",
-                team_name="t", env_file_path="/tmp/.env.local", github_repo=None,
+                project_name="x",
+                project_id="p",
+                environment_id="e",
+                team_name="t",
+                env_file_path="/tmp/.env.local",
+                github_repo=None,
             )
         assert r.confirmed is False
 
@@ -113,19 +141,28 @@ class TestTerminalConfirmSave:
         with patch("sys.stdin") as fake_stdin:
             fake_stdin.isatty.return_value = False
             r = popup._terminal_confirm_save(
-                project_name="x", project_id="p", environment_id="e",
-                team_name="t", env_file_path="/tmp/.env.local", github_repo=None,
+                project_name="x",
+                project_id="p",
+                environment_id="e",
+                team_name="t",
+                env_file_path="/tmp/.env.local",
+                github_repo=None,
             )
         assert r.confirmed is True
 
 
 class TestPromptDispatcher:
     def test_falls_back_to_terminal_when_tk_unavailable(self):
-        with patch("railguey.lib.popup._can_use_tk", return_value=False), \
-             patch("railguey.lib.popup._terminal_prompt_for_token") as fake:
+        with (
+            patch("railguey.lib.popup._can_use_tk", return_value=False),
+            patch("railguey.lib.popup._terminal_prompt_for_token") as fake,
+        ):
             fake.return_value = popup.TokenPromptResult(
-                token="x" * 30, token_name="gha-deploy",
-                push_to_github=False, github_repo="", cancelled=False,
+                token="x" * 30,
+                token_name="gha-deploy",
+                push_to_github=False,
+                github_repo="",
+                cancelled=False,
             )
             r = popup.prompt_for_token("https://railway.app/account/tokens")
             assert fake.called
@@ -158,7 +195,10 @@ class TestDetectGithubRepo:
             stderr = ""
 
         with p("railguey.lib.login.subprocess.run", return_value=FakeResult()):
-            assert _detect_github_repo(tmp_path) == "jetta-operating/jetta-intelligence-dot-com"
+            assert (
+                _detect_github_repo(tmp_path)
+                == "jetta-operating/jetta-intelligence-dot-com"
+            )
 
     def test_returns_none_when_no_remote(self, tmp_path):
         from railguey.lib.login import _detect_github_repo

--- a/tests/test_popup.py
+++ b/tests/test_popup.py
@@ -8,10 +8,8 @@ itself is unit-tested with patched stdin/stdout.
 
 from __future__ import annotations
 
-from io import StringIO
 from unittest.mock import patch
 
-import pytest
 
 from railguey.lib import popup
 

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -29,7 +29,13 @@ def test_fresh_session_navigates_then_answers(monkeypatch):
     monkeypatch.setattr(R, "_tmux", fake_tmux)
     # Not at prompt until after navigate; then emux ask returns the answer.
     prompt_state = {"at": False}
-    monkeypatch.setattr(R, "_capture", lambda lines=200: "Message the agent…" if prompt_state["at"] else "Select a project")
+    monkeypatch.setattr(
+        R,
+        "_capture",
+        lambda lines=200: (
+            "Message the agent…" if prompt_state["at"] else "Select a project"
+        ),
+    )
 
     def fake_run(cmd, capture_output, text, timeout):
         if cmd[1] == "navigate":
@@ -49,8 +55,12 @@ def test_fresh_session_navigates_then_answers(monkeypatch):
 def test_reused_session_skips_navigation(monkeypatch):
     """A live session already at the prompt must NOT re-navigate (keeps context)."""
     _base(monkeypatch)
-    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _Proc(returncode=0))  # session exists
-    monkeypatch.setattr(R, "_capture", lambda lines=200: "Message the agent…")  # already at prompt
+    monkeypatch.setattr(
+        R, "_tmux", lambda args, timeout=10: _Proc(returncode=0)
+    )  # session exists
+    monkeypatch.setattr(
+        R, "_capture", lambda lines=200: "Message the agent…"
+    )  # already at prompt
 
     seen = {"navigate": False}
 
@@ -68,16 +78,25 @@ def test_reused_session_skips_navigation(monkeypatch):
 
 
 def test_missing_emux(monkeypatch):
-    monkeypatch.setattr(R.shutil, "which", lambda name: None if name == "emux" else f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        R.shutil, "which", lambda name: None if name == "emux" else f"/usr/bin/{name}"
+    )
     out = R.research("anything")
     assert "error" in out and "emux" in out["error"]
 
 
 def test_navigation_fails_to_reach_prompt(monkeypatch):
     _base(monkeypatch)
-    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _Proc(returncode=1))  # fresh each check
-    monkeypatch.setattr(R, "_capture", lambda lines=200: "still loading…")  # never at prompt
-    monkeypatch.setattr(R.subprocess, "run",
-                        lambda cmd, capture_output, text, timeout: _Proc(stdout="", stderr="stalled"))
+    monkeypatch.setattr(
+        R, "_tmux", lambda args, timeout=10: _Proc(returncode=1)
+    )  # fresh each check
+    monkeypatch.setattr(
+        R, "_capture", lambda lines=200: "still loading…"
+    )  # never at prompt
+    monkeypatch.setattr(
+        R.subprocess,
+        "run",
+        lambda cmd, capture_output, text, timeout: _Proc(stdout="", stderr="stalled"),
+    )
     out = R.research("q?")
     assert "error" in out and "prompt" in out["error"]

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,0 +1,54 @@
+"""Tests for railguey.lib.research — the ssh railway.new agent driver.
+
+Mocks tmux + emux so no network / real session is needed.
+"""
+
+from railguey.lib import research as R
+
+
+def test_research_reaches_prompt_and_returns_answer(monkeypatch):
+    monkeypatch.setattr(R.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(R.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _ok())
+
+    # First capture: still in the menu. Second: at the agent prompt.
+    screens = iter(["Select a project", "Message the agent…"])
+    monkeypatch.setattr(R, "_capture", lambda s, lines=200: next(screens, "Message the agent…"))
+
+    # emux ask echoes the question then the answer; research() strips the echo.
+    def fake_run(cmd, capture_output, text, timeout):
+        return _proc(stdout="How do I deploy?\nUse railguey upload-source.\n")
+    monkeypatch.setattr(R.subprocess, "run", fake_run)
+
+    out = R.research("How do I deploy?")
+    assert out["ok"] is True
+    assert out["answer"] == "Use railguey upload-source."
+    assert out["via"] == "ssh railway.new"
+
+
+def test_research_missing_emux(monkeypatch):
+    monkeypatch.setattr(R.shutil, "which", lambda name: None if name == "emux" else f"/usr/bin/{name}")
+    out = R.research("anything")
+    assert "error" in out and "emux" in out["error"]
+
+
+def test_research_never_reaches_prompt(monkeypatch):
+    monkeypatch.setattr(R.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(R.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _ok())
+    monkeypatch.setattr(R, "_capture", lambda s, lines=200: "still loading…")
+    out = R.research("q?")
+    assert "error" in out and "prompt" in out["error"]
+
+
+class _Proc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+
+def _ok():
+    return _Proc(0, "", "")
+
+
+def _proc(stdout="", returncode=0, stderr=""):
+    return _Proc(returncode, stdout, stderr)

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,4 +1,4 @@
-"""Tests for railguey.lib.research — the ssh railway.new agent driver.
+"""Tests for railguey.lib.research — persistent, model-navigated agent driver.
 
 Mocks tmux + emux so no network / real session is needed.
 """
@@ -6,49 +6,78 @@ Mocks tmux + emux so no network / real session is needed.
 from railguey.lib import research as R
 
 
-def test_research_reaches_prompt_and_returns_answer(monkeypatch):
-    monkeypatch.setattr(R.shutil, "which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setattr(R.time, "sleep", lambda _s: None)
-    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _ok())
-
-    # First capture: still in the menu. Second: at the agent prompt.
-    screens = iter(["Select a project", "Message the agent…"])
-    monkeypatch.setattr(R, "_capture", lambda s, lines=200: next(screens, "Message the agent…"))
-
-    # emux ask echoes the question then the answer; research() strips the echo.
-    def fake_run(cmd, capture_output, text, timeout):
-        return _proc(stdout="How do I deploy?\nUse railguey upload-source.\n")
-    monkeypatch.setattr(R.subprocess, "run", fake_run)
-
-    out = R.research("How do I deploy?")
-    assert out["ok"] is True
-    assert out["answer"] == "Use railguey upload-source."
-    assert out["via"] == "ssh railway.new"
-
-
-def test_research_missing_emux(monkeypatch):
-    monkeypatch.setattr(R.shutil, "which", lambda name: None if name == "emux" else f"/usr/bin/{name}")
-    out = R.research("anything")
-    assert "error" in out and "emux" in out["error"]
-
-
-def test_research_never_reaches_prompt(monkeypatch):
-    monkeypatch.setattr(R.shutil, "which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setattr(R.time, "sleep", lambda _s: None)
-    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _ok())
-    monkeypatch.setattr(R, "_capture", lambda s, lines=200: "still loading…")
-    out = R.research("q?")
-    assert "error" in out and "prompt" in out["error"]
-
-
 class _Proc:
     def __init__(self, returncode=0, stdout="", stderr=""):
         self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
 
 
-def _ok():
-    return _Proc(0, "", "")
+def _base(monkeypatch):
+    monkeypatch.setattr(R.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(R.time, "sleep", lambda _s: None)
 
 
-def _proc(stdout="", returncode=0, stderr=""):
-    return _Proc(returncode, stdout, stderr)
+def test_fresh_session_navigates_then_answers(monkeypatch):
+    _base(monkeypatch)
+    calls = {"has": 0}
+
+    def fake_tmux(args, timeout=10):
+        if args[0] == "has-session":
+            calls["has"] += 1
+            return _Proc(returncode=1)  # session does not exist -> fresh
+        return _Proc(returncode=0)
+
+    monkeypatch.setattr(R, "_tmux", fake_tmux)
+    # Not at prompt until after navigate; then emux ask returns the answer.
+    prompt_state = {"at": False}
+    monkeypatch.setattr(R, "_capture", lambda lines=200: "Message the agent…" if prompt_state["at"] else "Select a project")
+
+    def fake_run(cmd, capture_output, text, timeout):
+        if cmd[1] == "navigate":
+            prompt_state["at"] = True  # navigation reached the prompt
+            return _Proc(stdout="reached (until) in 3 step(s)")
+        # emux ask
+        return _Proc(stdout="How do I deploy?\nUse railguey upload-source.\n")
+
+    monkeypatch.setattr(R.subprocess, "run", fake_run)
+
+    out = R.research("How do I deploy?")
+    assert out["ok"] is True
+    assert out["answer"] == "Use railguey upload-source."
+    assert out["new_conversation"] is True
+
+
+def test_reused_session_skips_navigation(monkeypatch):
+    """A live session already at the prompt must NOT re-navigate (keeps context)."""
+    _base(monkeypatch)
+    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _Proc(returncode=0))  # session exists
+    monkeypatch.setattr(R, "_capture", lambda lines=200: "Message the agent…")  # already at prompt
+
+    seen = {"navigate": False}
+
+    def fake_run(cmd, capture_output, text, timeout):
+        if cmd[1] == "navigate":
+            seen["navigate"] = True
+        return _Proc(stdout="and logs?\nUse railguey logs <svc>.\n")
+
+    monkeypatch.setattr(R.subprocess, "run", fake_run)
+
+    out = R.research("and logs?")
+    assert out["ok"] is True
+    assert seen["navigate"] is False  # reused conversation, no re-nav
+    assert out["new_conversation"] is False
+
+
+def test_missing_emux(monkeypatch):
+    monkeypatch.setattr(R.shutil, "which", lambda name: None if name == "emux" else f"/usr/bin/{name}")
+    out = R.research("anything")
+    assert "error" in out and "emux" in out["error"]
+
+
+def test_navigation_fails_to_reach_prompt(monkeypatch):
+    _base(monkeypatch)
+    monkeypatch.setattr(R, "_tmux", lambda args, timeout=10: _Proc(returncode=1))  # fresh each check
+    monkeypatch.setattr(R, "_capture", lambda lines=200: "still loading…")  # never at prompt
+    monkeypatch.setattr(R.subprocess, "run",
+                        lambda cmd, capture_output, text, timeout: _Proc(stdout="", stderr="stalled"))
+    out = R.research("q?")
+    assert "error" in out and "prompt" in out["error"]


### PR DESCRIPTION
## What

Adds `railguey research "<question>"` — **product research from Railway's own agent**. It spins up a throwaway tmux session running the `ssh railway.new` agent chat, walks the menu to the prompt, asks your question, and returns the agent's docs-backed answer.

## How it reuses emux

The ask-and-wait step is delegated to **`emux ask`** — emux's reusable "talk to another AI through its TUI" primitive (see eidos-agi/emux#converse). railguey only knows the railway.new menu navigation; emux knows how to converse. Passes `--busy thinking` so the agent's streaming indicator isn't mistaken for the reply.

## Usage

```
railguey research "How do I add a cron schedule to a service?"
railguey research "What regions can I deploy to?" --settle 4
```

## Requires

`tmux` + `emux` on PATH (`uv tool install emux`).

## Tests

`tests/test_research.py` — mocked orchestration (reaches prompt, strips echo), missing-emux guard, never-reaches-prompt. **3 pass.** Live-verified end-to-end against `ssh railway.new`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)